### PR TITLE
fix: updated "All Sources" tooltip's position and scrolling behavior

### DIFF
--- a/client/src/app/(main)/discover/DiscoverInput.tsx
+++ b/client/src/app/(main)/discover/DiscoverInput.tsx
@@ -221,8 +221,8 @@ export default function DiscoverInput({
                                         <ChevronDown className="h-3.5 w-3.5" />
                                     </button>
                                 </PopoverTrigger>
-                                <PopoverContent className="w-64 p-2" align="start">
-                                    <div className="space-y-1">
+                                <PopoverContent className="w-64 p-2" align="start" side="bottom" avoidCollisions={false}>
+                                    <div className="space-y-1 max-h-64 overflow-y-auto">
                                         {webSources.map((source) => {
                                             const isSelected = selectedSources.includes(source.key)
                                             return (


### PR DESCRIPTION
hello @sabaimran,

i made a minor fix to the position of the All Sources tooltip (i.e., decided to position it under the button to ensure consistency with other tooltips' positions) and also made it scrollable. 


<img width="740" height="496" alt="Screenshot 2026-02-10 at 6 57 15 PM" src="https://github.com/user-attachments/assets/04cc0446-9057-47d9-b553-8d45c0a27aff" />

<img width="704" height="486" alt="Screenshot 2026-02-10 at 6 57 37 PM" src="https://github.com/user-attachments/assets/39ff241f-88c0-419c-afc0-6fa025b38393" />

