### PR TITLE
[benchmark] post-hoc OpenAlex data with Exa initial search results

### DIFF
--- a/server/app/benchmark/discover_latency.py
+++ b/server/app/benchmark/discover_latency.py
@@ -1,0 +1,201 @@
+from dotenv import load_dotenv
+load_dotenv()
+
+import json
+import re
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from urllib.parse import unquote
+
+import requests
+
+from app.helpers.exa_search import search_exa
+from app.helpers.paper_search import extract_doi_from_url, get_doi, get_work_by_doi
+
+BENCHMARK_DIR = Path(__file__).resolve().parent
+
+QUERIES = [
+    "Human-AI interaction",
+    "Reinforcement learning and games"
+]
+
+
+def get_doi_from_url(url: str) -> str | None:
+    """
+    Get DOI from a publisher or paper URL.
+    Tries embedded DOI first, then known publisher URL patterns (Nature, MDPI, arXiv).
+    """
+    if not url or not url.strip():
+        return None
+    
+    # Normalize the URL before parsing the DOI
+    url = unquote(url.strip())
+
+    # URL already contains a DOI
+    doi = extract_doi_from_url(url)
+    if doi:
+        return doi
+
+    # Nature: .../articles/<slug>  ->  10.1038/<slug>
+    match = re.search(r"nature\.com/articles/([^/?\s]+)", url)
+    if match:
+        return f"10.1038/{match.group(1)}"
+
+    # MDPI: .../ISSN/vol/issue/article  ->  10.3390/<abbrev><vol><issue><article>
+    match = re.search(r"mdpi\.com/(\d{4}-\d{4})/(\d+)/(\d+)/(\d+)", url)
+    if match:
+        issn, vol, issue, art = match.groups()
+        mdpi_suffix = {
+            "2076-3417": "app",
+            "2075-5309": "buildings",
+            "1999-4907": "f",
+            "2227-7390": "mathematics",
+            "1422-0067": "ijms",
+            "2072-6643": "nu",
+            "2073-4395": "agronomy",
+            "2071-1050": "su",
+            "2076-2615": "animals",
+            "2079-9292": "electronics",
+        }
+        abbrev = mdpi_suffix.get(issn)
+        if abbrev:
+            return f"10.3390/{abbrev}{vol}{issue}{art}"
+
+    # arXiv: .../abs/2510.17753 or .../pdf/2405.15051  ->  10.48550/arXiv.2510.17753
+    match = re.search(r"arxiv\.org/(?:abs|pdf)/(\d{4}\.\d{4,5})", url)
+    if match:
+        return f"10.48550/arXiv.{match.group(1)}"
+
+    # ScienceDirect PII: .../pii/<PII>  ->  10.1016/<PII> or lookup via Crossref alternative-id
+    match = re.search(r"sciencedirect\.com/science/article/pii/([A-Z0-9()\-]+)", url, re.IGNORECASE)
+    if match:
+        pii = match.group(1)
+        candidate_doi = f"10.1016/{pii}"
+        try:
+            r = requests.head(
+                f"https://doi.org/{candidate_doi}",
+                allow_redirects=True,
+                timeout=5,
+                headers={"User-Agent": "OpenPaperBenchmark/1.0 (https://github.com/openpaper)"},
+            )
+            if r.ok or 300 <= r.status_code < 400:
+                return candidate_doi
+        except requests.RequestException:
+            pass
+        # Crossref stores PII as alternative-id; look up DOI
+        try:
+            cr = requests.get(
+                "https://api.crossref.org/works",
+                params={"filter": f"alternative-id:{pii}", "rows": 1},
+                timeout=10,
+                headers={"User-Agent": "OpenPaperBenchmark/1.0 (https://github.com/openpaper)"},
+            )
+            if cr.ok:
+                items = cr.json().get("message", {}).get("items", [])
+                if items and items[0].get("DOI"):
+                    return items[0]["DOI"]
+        except requests.RequestException:
+            pass
+        return candidate_doi
+
+    return None
+
+
+def _work_to_openalex_result_dict(work) -> dict:
+    """Convert OpenAlex work to OpenAlexResult-shaped dict (authors, cited_by_count, text, etc.)."""
+    authors = []
+    institutions_set = set()
+    if work.authorships:
+        for a in work.authorships:
+            if a.author and a.author.display_name:
+                authors.append(a.author.display_name)
+            if a.institutions:
+                for inst in a.institutions:
+                    if inst.display_name:
+                        institutions_set.add(inst.display_name)
+    source = None
+    if work.primary_location and work.primary_location.source:
+        source = work.primary_location.source.display_name
+    url = ""
+    if work.primary_location and work.primary_location.landing_page_url:
+        url = work.primary_location.landing_page_url
+    elif work.doi:
+        url = work.doi if work.doi.startswith("http") else f"https://doi.org/{work.doi}"
+    else:
+        url = work.id or ""
+    return {
+        "title": (work.title or "").strip(),
+        "url": url,
+        "authors": authors,
+        "published_date": work.publication_date,
+        "text": work.abstract,
+        "highlights": [],
+        "highlight_scores": [],
+        "favicon": None,
+        "cited_by_count": work.cited_by_count,
+        "source": source,
+        "institutions": list(institutions_set),
+    }
+
+
+def _exa_to_openalex_result_dict(result) -> dict:
+    """Map EXA result to OpenAlexResult-shaped dict."""
+    return {
+        "title": result.title,
+        "url": result.url,
+        "authors": result.authors or [],
+        "published_date": result.published_date,
+        "text": result.text,
+        "highlights": result.highlights or [],
+        "highlight_scores": result.highlight_scores or [],
+        "favicon": result.favicon,
+        "cited_by_count": None,
+        "source": None,
+        "institutions": [],
+    }
+
+
+def _enrich_one_result(result) -> dict:
+    """Resolve DOI and enrich one EXA result (work unit for parallel execution)."""
+    doi = get_doi_from_url(result.url)
+    if not doi:
+        doi = get_doi(result.title, result.authors)
+    work = get_work_by_doi(doi) if doi else None
+    if work and work.title and work.title.strip():
+        return _work_to_openalex_result_dict(work)
+    return _exa_to_openalex_result_dict(result)
+
+
+def benchmark_exa_only_latency(query: str):
+    start_time = time.time()
+    results = search_exa(query)
+    end_time = time.time()
+    print(json.dumps([r.to_dict() for r in results], indent=2))
+    with open(BENCHMARK_DIR / f"exa_results_{query}.json", "w") as f:
+        json.dump([r.to_dict() for r in results], f, indent=2)
+    return end_time - start_time
+
+def benchmark_openalex_exa_latency(query: str):
+    start_time = time.time()
+    results = search_exa(query)
+
+    # Enrich in parallel (one task per Exa result), preserve order
+    max_workers = min(10, len(results)) if results else 1
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        enriched_results = list(executor.map(_enrich_one_result, results))
+
+    end_time = time.time()
+
+    with open(BENCHMARK_DIR / f"openalex_exa_results_{query}.json", "w") as f:
+        json.dump(enriched_results, f, indent=2)
+
+    print(json.dumps(enriched_results, indent=2))
+    return end_time - start_time
+
+if __name__ == "__main__":
+    latency_exa_only = benchmark_exa_only_latency(QUERIES[0])
+    print(f"Latency exa only: {latency_exa_only} seconds")
+    latency_openalex_exa = benchmark_openalex_exa_latency(QUERIES[0])
+    print(f"Latency openalex exa: {latency_openalex_exa} seconds")
+    

--- a/server/app/benchmark/exa_results_Human-AI interaction.json
+++ b/server/app/benchmark/exa_results_Human-AI interaction.json
@@ -1,0 +1,152 @@
+[
+  {
+    "title": "Human-AI interaction research agenda: A user-centered perspective",
+    "url": "https://www.sciencedirect.com/science/article/pii/S2543925124000147",
+    "authors": [],
+    "published_date": null,
+    "text": "Human-AI interaction research agenda: A user-centered perspective - ScienceDirect\n[Skip to main content] [Skip to article] \n[![Elsevier logo] ScienceDirect] \n[My account] \n[Sign in] \n* [View**PDF**] \n* Download full issue\nSearch ScienceDirect\n## Outline\n1. [Abstract] \n2. [Keywords] \n3. [1. Introduction] \n4. [2. Understanding AI systems] \n5. [3. Human-AI interaction research themes] \n6. [4. Human-AI interaction theoretical foundations]",
+    "highlights": [
+      "Human-AI interaction research agenda: A user-centered perspective - ScienceDirect ... * Download full issue\nSearch ScienceDirect\n## Outline\n1. [Abstract] \n2. [Keywords] \n3. [1. Introduction] 4. [2. Understanding AI systems] \n5. [3. Human-AI interaction research themes] 6. [4. Human-AI interaction theoretical foundations]"
+    ],
+    "highlight_scores": [
+      0.10302734375
+    ],
+    "favicon": "https://www.sciencedirect.com/shared-assets/103/images/favSD.ico"
+  },
+  {
+    "title": "The brain side of human-AI interactions in the long-term - Nature",
+    "url": "https://www.nature.com/articles/s44387-025-00063-1",
+    "authors": [],
+    "published_date": "2026-01-27T00:00:00.000Z",
+    "text": "The brain side of human-AI interactions in the long-term: the \u201c3R principle\u201d | npj Artificial Intelligence\n\n[Download PDF] \n\n### Subjects\n\n- [Psychology] \n- [Neuroscience] \n\nNeuroplasticity is shaped by how humans interact with AI. We argue that passive, uncritical, reliance on AI may weaken activity-dependent brain plasticity and erode cognition, whereas active co-creation can sustain or enhance it. Drawing on plasticity rules and ethical considerations, we propose the",
+    "highlights": [
+      "The brain side of human-AI interactions in the long-term: the \u201c3R principle\u201d | npj Artificial Intelligence [Download PDF] \n\n### Subjects\n\n- [Psychology] \n- [Neuroscience] Neuroplasticity is shaped by how humans interact with AI. We argue that passive, uncritical, reliance on AI may weaken activity-dependent brain plasticity and erode cognition, whereas active co-creation can sustain or enhance it. Drawing on plasticity rules and ethical considerations, we propose the"
+    ],
+    "highlight_scores": [
+      0.1533203125
+    ],
+    "favicon": "https://www.nature.com/static/images/favicons/nature/apple-touch-icon-f39cb19454.png"
+  },
+  {
+    "title": "Human\u2013Artificial Intelligence (AI) Interaction: Latest Advances and Prospects",
+    "url": "https://www.mdpi.com/2076-3417/15/22/12218",
+    "authors": [
+      "Tommi K\u00e4rkk\u00e4inen"
+    ],
+    "published_date": "2025-11-18T00:00:00.000Z",
+    "text": "Human\u2013Artificial Intelligence (AI) Interaction: Latest Advances and Prospects\n\nNext Article in Journal\n\n[The Impact of Speed Bumps on Traffic Flow Speed in Urban Road Networks] \n\nPrevious Article in Journal\n\n[From Dataset to Model: A Romanian\u2013English Corpus and Fine-Tuned Cross-Lingual Embeddings for Text and Tabular Retrieval] \n\nPrevious Article in Special Issue\n\n[A Review of Brain\u2013Computer Interface-Based Language Decoding: From Signal Interpretation to Intelligent Communication]",
+    "highlights": [
+      "Human\u2013Artificial Intelligence (AI) Interaction: Latest Advances and Prospects\n\nNext Article in Journal [The Impact of Speed Bumps on Traffic Flow Speed in Urban Road Networks] \n\nPrevious Article in Journal [From Dataset to Model: A Romanian\u2013English Corpus and Fine-Tuned Cross-Lingual Embeddings for Text and Tabular Retrieval] Previous Article in Special Issue [A Review of Brain\u2013Computer Interface-Based Language Decoding: From Signal Interpretation to Intelligent Communication]"
+    ],
+    "highlight_scores": [
+      -0.0966796875
+    ],
+    "favicon": "https://pub.mdpi-res.com/img/mask-icon-128.svg?c1c7eca266cd7013?1770645935"
+  },
+  {
+    "title": "Human-AI interaction - ScienceDirect.com",
+    "url": "https://www.sciencedirect.com/science/article/pii/S2543925123000220",
+    "authors": [
+      "E.D.V. Calderon, T.L. James, P.B. Lowry"
+    ],
+    "published_date": null,
+    "text": "[Skip to main content] [Skip to article] \n\n- [View\u00a0**PDF**] \n- Download full issue\n\nSearch ScienceDirect\n\n## Outline\n\n2. [1\\. Introduction] \n3. [2\\. A general framework of Human-AI interaction] \n4. [3\\. Papers in this special issue] \n5. [References] \n\n## [Cited by (2)] \n\n## Figures (3)\n\n1. [![Fig.1. The agency role of AI]] \n2. [![Fig.2. Human-AI collaboration continuum]] \n3. [![Fig.3. A general research framework]]",
+    "highlights": [
+      "A general framework of Human-AI interaction] \n4. [3\\. Papers in this special issue] 5. [References] ## [Cited by (2)] \n\n## Figures (3) 1. [![Fig.1. The agency role of AI]] \n2. [![Fig.2. Human-AI collaboration continuum]] 3. [![Fig.3. A general research framework]]"
+    ],
+    "highlight_scores": [
+      0.021240234375
+    ],
+    "favicon": null
+  },
+  {
+    "title": "Guidelines for Human-AI Interaction",
+    "url": "https://www.semanticscholar.org/paper/Guidelines-for-Human-AI-Interaction-Amershi-Weld/ad3cf68bae32d21f25ac142287d4a556155619d2",
+    "authors": [],
+    "published_date": "2019-05-02T00:00:00.000Z",
+    "text": "[PDF] Guidelines for Human-AI Interaction | Semantic Scholar\n[Skip to search form] [Skip to main content] [Skip to account menu] \n[Semantic ScholarSemantic Scholar&#x27;s Logo] \nSearch 232,120,152 papers from all fields of science\nSearch\n* DOI:[10.1145/3290605.3300233] \n* Corpus ID: 86866942# Guidelines for Human-AI Interaction\n```\n@article{Amershi2019GuidelinesFH,\ntitle={Guidelines for Human-AI Interaction},\nauthor={Saleema Amershi and Daniel S. Weld",
+    "highlights": [
+      "[PDF] Guidelines for Human-AI Interaction | Semantic Scholar ... Search 232,120,152 papers from all fields of science\nSearch\n* DOI:[10.1145/3290605.3300233] * Corpus ID: 86866942# Guidelines for Human-AI Interaction\n```\n@article{Amershi2019GuidelinesFH, title={Guidelines for Human-AI Interaction},\nauthor={Saleema Amershi and Daniel S. Weld"
+    ],
+    "highlight_scores": [
+      0.08544921875
+    ],
+    "favicon": "https://cdn.semanticscholar.org/d5a7fc2a8d2c90b9/img/favicon-32x32.png"
+  },
+  {
+    "title": "Human-AI interaction in safety-critical network infrastructures",
+    "url": "https://www.sciencedirect.com/science/article/pii/S258900422501661X",
+    "authors": [],
+    "published_date": "2025-09-19T00:00:00.000Z",
+    "text": "[Skip to main content] [Skip to article] \n\n- View\u00a0**PDF**\n- Download full issue\n\nSearch ScienceDirect\n\n[**iScience**] \n\n[Volume 28, Issue 9], 19 September 2025, 113400\n\n# Perspective Human-AI interaction in safety-critical network infrastructures\n\nAuthor links open overlay panelMarcoMussi1, Alberto MariaMetelli1, MarcelloRestelli1, GianvitoLosapio1, Ricardo J.Bessa2, DanielBoos3, ClarkBorst4, GiuliaLeto4, AlbertoCastagna5, RicardoChavarriaga6, DuarteDias2,",
+    "highlights": [
+      "Perspective Human-AI interaction in safety-critical network infrastructures Author links open overlay panelMarcoMussi1, Alberto MariaMetelli1, MarcelloRestelli1, GianvitoLosapio1, Ricardo J.Bessa2, DanielBoos3, ClarkBorst4, GiuliaLeto4, AlbertoCastagna5, RicardoChavarriaga6"
+    ],
+    "highlight_scores": [
+      0.07275390625
+    ],
+    "favicon": "https://www.sciencedirect.com/shared-assets/103/images/favSD.ico"
+  },
+  {
+    "title": "From Explainable to Interactive AI: A Literature Review on Current Trends in Human-AI Interaction",
+    "url": "https://arxiv.org/pdf/2405.15051",
+    "authors": [
+      "Muhammad Raees; Inge Meijerink; Ioanna Lykourentzou; Vassilis-Javed Khan; Konstantinos Papangelis;"
+    ],
+    "published_date": "2024-05-27T00:00:00.000Z",
+    "text": "arXiv reCAPTCHA\n[![Cornell University]] \n[We gratefully acknowledge support from\nthe Simons Foundation and member institutions.] \n# [![arxiv logo]]",
+    "highlights": [
+      "arXiv reCAPTCHA\n[![Cornell University]] \n[We gratefully acknowledge support from the Simons Foundation and member institutions.] \n# [![arxiv logo]]"
+    ],
+    "highlight_scores": [
+      -0.435546875
+    ],
+    "favicon": null
+  },
+  {
+    "title": "Human-AI Interaction and Collaboration - Cambridge University Press",
+    "url": "https://www.cambridge.org/core/books/humanai-interaction-and-collaboration/CC47EFB06171F714256FD11EFE38DC16",
+    "authors": [
+      "Dan Wu"
+    ],
+    "published_date": "2025-09-19T00:00:00.000Z",
+    "text": "\n \n The integration of AI into information systems will affect the way users interface with these systems. This exploration of the interaction and collaboration between humans and AI reveals its potential and challenges, covering issues such as data privacy, credibility of results, misinformation, and search interactions. Later chapters delve into application domains such as healthcare and scientific discovery. In addition to providing new perspectives on and methods for developing",
+    "highlights": [
+      "The integration of AI into information systems will affect the way users interface with these systems. This exploration of the interaction and collaboration between humans and AI reveals its potential and challenges, covering issues such as data privacy, credibility of results, misinformation, and search interactions. Later chapters delve into application domains such as healthcare and scientific discovery. In addition to providing new perspectives on and methods for developing"
+    ],
+    "highlight_scores": [
+      -0.1728515625
+    ],
+    "favicon": "https://www.cambridge.org/core/cambridge-core/public/images/favicon.ico"
+  },
+  {
+    "title": "Examining human-AI interaction in real-world healthcare beyond the ...",
+    "url": "https://www.nature.com/articles/s41746-025-01559-5",
+    "authors": [],
+    "published_date": "2025-03-19T00:00:00.000Z",
+    "text": "Examining human-AI interaction in real-world healthcare beyond the laboratory | npj Digital Medicine\n[Skip to main content] \nThank you for visiting nature.com. You are using a browser version with limited support for CSS. To obtain\nthe best experience, we recommend you use a more up to date browser (or turn off compatibility mode in\nInternet Explorer). In the meantime, to ensure continued support, we are displaying the site without styles\nand JavaScript.\nAdvertisement\n[![npj Digital Medicine]]",
+    "highlights": [
+      "Examining human-AI interaction in real-world healthcare beyond the laboratory | npj Digital Medicine ... Thank you for visiting nature.com. You are using a browser version with limited support for CSS. To obtain the best experience, we recommend you use a more up to date browser (or turn off compatibility mode in Internet Explorer). In the meantime, to ensure continued support, we are displaying the site without styles and JavaScript.\nAdvertisement\n[![npj Digital Medicine]]"
+    ],
+    "highlight_scores": [
+      -0.16796875
+    ],
+    "favicon": "https://www.nature.com/static/images/favicons/nature/favicon-32x32-3fe59ece92.png"
+  },
+  {
+    "title": "Human-AI Interactions: Cognitive, Behavioral, and Emotional Impacts",
+    "url": "https://arxiv.org/abs/2510.17753",
+    "authors": [
+      "[Submitted on 20 Oct 2025 (v1), last revised 21 Oct 2025 (this version, v2)]"
+    ],
+    "published_date": "2025-10-20T00:00:00.000Z",
+    "text": "[2510.17753] Human-AI Interactions: Cognitive, Behavioral, and Emotional Impacts\n[Skip to main content] \n[![Cornell University]] \nWe gratefully acknowledge support from the Simons Foundation, [member institutions], and all contributors.\n[Donate] \n[] \n[![arxiv logo]] &gt; [cs] &gt; arXiv:2510.17753\n[Help] | [Advanced Search] \nAll fields\nTitle\nAuthor\nAbstract\nComments\nJournal reference\nACM",
+    "highlights": [
+      "[2510.17753] Human-AI Interactions: Cognitive, Behavioral, and Emotional Impacts\n[Skip to main content] ... We gratefully acknowledge support from the Simons Foundation, [member institutions], and all contributors.\n[Donate] [] \n[![arxiv logo]] > [cs] > arXiv:2510.17753\n[Help] | [Advanced Search] \nAll fields\nTitle\nAuthor\nAbstract Comments\nJournal reference\nACM"
+    ],
+    "highlight_scores": [
+      -0.1181640625
+    ],
+    "favicon": "https://arxiv.org/static/browse/0.3.4/images/icons/favicon-32x32.png"
+  }
+]

--- a/server/app/benchmark/openalex_exa_results_Human-AI interaction.json
+++ b/server/app/benchmark/openalex_exa_results_Human-AI interaction.json
@@ -1,0 +1,254 @@
+[
+  {
+    "title": "Human-AI interaction research agenda: A user-centered perspective",
+    "url": "https://doi.org/10.1016/j.dim.2024.100078",
+    "authors": [
+      "Jiang Tingting",
+      "Zhumo Sun",
+      "Shiting Fu",
+      "Yan Lv"
+    ],
+    "published_date": "2024-07-15",
+    "text": "The rapid growth of artificial intelligence (AI) has given rise to the field of Human-AI Interaction (HAII). This study meticulously reviewed the research themes, theoretical foundations, and methodological frameworks of the HAII field, aiming to construct a comprehensive overview of this field and provide robust support for future investigations. HAII research themes include human-AI collaboration, competition, conflict, and symbiosis. Theories drawn from communication, psychology, and sociology support these studies, while the employed methods include both self-reporting and observational approaches commonly utilized in user studies. It is suggested that future research should broaden its focus to encompass diverse user groups, AI roles, and tasks. Moreover, it is necessary to develop multi-disciplinary theories and integrate multi-level research methods to support the sustained development of the field. This study not only furnishes indispensable theoretical and practical insights for forthcoming research endeavors but also catalyzes the realization of a future distinguished by seamless interaction between humans and AI.",
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 58,
+    "source": "Data and Information Management",
+    "institutions": [
+      "Wuhan University"
+    ]
+  },
+  {
+    "title": "The brain side of human-AI interactions in the long-term: the \u201c3R principle\u201d",
+    "url": "https://doi.org/10.1038/s44387-025-00063-1",
+    "authors": [
+      "Simone Rossi",
+      "Valter Fraccaro",
+      "Riccardo Manzotti"
+    ],
+    "published_date": "2026-01-27",
+    "text": "Neuroplasticity is shaped by how humans interact with AI. We argue that passive, uncritical, reliance on AI may weaken activity-dependent brain plasticity and erode cognition, whereas active co-creation can sustain or enhance it. Drawing on plasticity rules and ethical considerations, we propose the 3R principle\u2014Results, Responses, Responsibility\u2014as a preventive framework for cognitive hygiene, urging education towards AI use to preserve agency, meaning-making, and long-term brain health.",
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 0,
+    "source": "npj Artificial Intelligence",
+    "institutions": [
+      "IULM University",
+      "University of Siena"
+    ]
+  },
+  {
+    "title": "Human\u2013Artificial Intelligence (AI) Interaction: Latest Advances and Prospects",
+    "url": "https://doi.org/10.3390/app152212218",
+    "authors": [
+      "Ant\u00f3nio Correia",
+      "Daniel Schneider",
+      "Benjamim Fonseca",
+      "Tommi K\u00e4rkk\u00e4inen"
+    ],
+    "published_date": "2025-11-18",
+    "text": "In recent years, artificial intelligence (AI) has been embedded in everyday life contexts and has empowered systems with the capacity to learn, adapt, and make decisions autonomously [...]",
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 0,
+    "source": "Applied Sciences",
+    "institutions": [
+      "Universidade Federal do Rio de Janeiro",
+      "University of Tr\u00e1s-os-Montes and Alto Douro",
+      "University of Jyv\u00e4skyl\u00e4",
+      "INESC TEC"
+    ]
+  },
+  {
+    "title": "Human-AI interaction",
+    "url": "https://doi.org/10.1016/j.dim.2023.100048",
+    "authors": [
+      "Yongqiang Sun",
+      "Xiao\u2010Liang Shen",
+      "Kem Z.K. Zhang"
+    ],
+    "published_date": "2023-09-01",
+    "text": null,
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 7,
+    "source": "Data and Information Management",
+    "institutions": [
+      "Wuhan University",
+      "Lakehead University"
+    ]
+  },
+  {
+    "title": "Guidelines for Human-AI Interaction",
+    "url": "https://doi.org/10.1145/3290605.3300233",
+    "authors": [
+      "Saleema Amershi",
+      "Dan Weld",
+      "Mihaela Vorvoreanu",
+      "Adam Fourney",
+      "Besmira Nushi",
+      "Penny Collisson",
+      "Jina Suh",
+      "Shamsi T. Iqbal",
+      "Paul N. Bennett",
+      "Kori Inkpen",
+      "Jaime Teevan",
+      "Ruth Kikin-Gil",
+      "Eric Horvitz"
+    ],
+    "published_date": "2019-04-29",
+    "text": "Advances in artificial intelligence (AI) frame opportunities and challenges for user interface design. Principles for human-AI interaction have been discussed in the human-computer interaction community for over two decades, but more study and innovation are needed in light of advances in AI and the growing uses of AI technologies in human-facing applications. We propose 18 generally applicable design guidelines for human-AI interaction. These guidelines are validated through multiple rounds of evaluation including a user study with 49 design practitioners who tested the guidelines against 20 popular AI-infused products. The results verify the relevance of the guidelines over a spectrum of interaction scenarios and reveal gaps in our knowledge, highlighting opportunities for further research. Based on the evaluations, we believe the set of design guidelines can serve as a resource to practitioners working on the design of applications and features that harness AI technologies, and to researchers interested in the further development of human-AI interaction design principles.",
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 1535,
+    "source": null,
+    "institutions": [
+      "Microsoft (United States)",
+      "University of Washington"
+    ]
+  },
+  {
+    "title": "Human-AI interaction in safety-critical network infrastructures",
+    "url": "https://doi.org/10.1016/j.isci.2025.113400",
+    "authors": [
+      "Marco Mussi",
+      "Alberto Maria Metelli",
+      "Marcello Restelli",
+      "Gianvito Losapio",
+      "Ricardo J. Bessa",
+      "Daniel Boos",
+      "Christopher L. Borst",
+      "G. Leto",
+      "Alberto Castagna",
+      "Ricardo Chavarriaga",
+      "Dylmar Penteado Dias",
+      "Adrian Egli",
+      "Andrina Eisenegger",
+      "Yassine El Manyari",
+      "Anton R. Fuxj\u00e4ger",
+      "Joaquim Geraldes",
+      "Samira Hamouche",
+      "Mohamed Salah El-Din Hassouna",
+      "Bruno Lemetayer",
+      "Milad Leyli-Abadi",
+      "Roman Liessner",
+      "Jonas Lundberg",
+      "Antoine Marot",
+      "Maroua Meddeb",
+      "Viola Schiaffonati",
+      "Matthias Schneider",
+      "Thilo Stadelmann",
+      "Julia Usher",
+      "Herke van Hoof",
+      "Jan Viebahn",
+      "Toni Waefler",
+      "Giacomo Zanotti"
+    ],
+    "published_date": "2025-08-21",
+    "text": null,
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 1,
+    "source": "iScience",
+    "institutions": [
+      "ZHAW Zurich University of Applied Sciences",
+      "Fraunhofer Institute for Energy Economics and Energy System Technology",
+      "Link\u00f6ping University",
+      "\u00c9lectricit\u00e9 de France (France)",
+      "University of Amsterdam",
+      "FHNW University of Applied Sciences and Arts",
+      "Institut de Recherche Technologique SystemX",
+      "University of Kassel",
+      "Swiss Federal Railways",
+      "Deutsche Bahn (Germany)",
+      "Tennet (Netherlands)",
+      "Politecnico di Milano",
+      "Delft University of Technology",
+      "INESC TEC"
+    ]
+  },
+  {
+    "title": "From Explainable to Interactive AI: A Literature Review on Current Trends in Human-AI Interaction",
+    "url": "http://arxiv.org/abs/2405.15051",
+    "authors": [
+      "Muhammad Raees",
+      "Inge Meijerink",
+      "Ioanna Lykourentzou",
+      "Vassilis-Javed Khan",
+      "Konstantinos Papagelis"
+    ],
+    "published_date": "2024-05-23",
+    "text": "AI systems are increasingly being adopted across various domains and application areas. With this surge, there is a growing research focus and societal concern for actively involving humans in developing, operating, and adopting these systems. Despite this concern, most existing literature on AI and Human-Computer Interaction (HCI) primarily focuses on explaining how AI systems operate and, at times, allowing users to contest AI decisions. Existing studies often overlook more impactful forms of user interaction with AI systems, such as giving users agency beyond contestability and enabling them to adapt and even co-design the AI's internal mechanics. In this survey, we aim to bridge this gap by reviewing the state-of-the-art in Human-Centered AI literature, the domain where AI and HCI studies converge, extending past Explainable and Contestable AI, delving into the Interactive AI and beyond. Our analysis contributes to shaping the trajectory of future Interactive AI design and advocates for a more user-centric approach that provides users with greater agency, fostering not only their understanding of AI's workings but also their active engagement in its development and evolution.",
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 3,
+    "source": "arXiv (Cornell University)",
+    "institutions": []
+  },
+  {
+    "title": "Human-AI Interaction and Collaboration - Cambridge University Press",
+    "url": "https://www.cambridge.org/core/books/humanai-interaction-and-collaboration/CC47EFB06171F714256FD11EFE38DC16",
+    "authors": [
+      "Dan Wu"
+    ],
+    "published_date": "2025-09-19T00:00:00.000Z",
+    "text": "\n \n The integration of AI into information systems will affect the way users interface with these systems. This exploration of the interaction and collaboration between humans and AI reveals its potential and challenges, covering issues such as data privacy, credibility of results, misinformation, and search interactions. Later chapters delve into application domains such as healthcare and scientific discovery. In addition to providing new perspectives on and methods for developing",
+    "highlights": [
+      "The integration of AI into information systems will affect the way users interface with these systems. This exploration of the interaction and collaboration between humans and AI reveals its potential and challenges, covering issues such as data privacy, credibility of results, misinformation, and search interactions. Later chapters delve into application domains such as healthcare and scientific discovery. In addition to providing new perspectives on and methods for developing"
+    ],
+    "highlight_scores": [
+      -0.1728515625
+    ],
+    "favicon": "https://www.cambridge.org/core/cambridge-core/public/images/favicon.ico",
+    "cited_by_count": null,
+    "source": null,
+    "institutions": []
+  },
+  {
+    "title": "Examining human-AI interaction in real-world healthcare beyond the laboratory",
+    "url": "https://doi.org/10.1038/s41746-025-01559-5",
+    "authors": [
+      "Magdalena Wekenborg",
+      "Stephen Gilbert",
+      "Jakob Nikolas Kather"
+    ],
+    "published_date": "2025-03-19",
+    "text": "Abstract Artificial Intelligence (AI) is revolutionizing healthcare, but its true impact depends on seamless human interaction. While most research focuses on technical metrics, we lack frameworks to measure the compatibility or synergy of real-world human-AI interactions in healthcare settings. We propose a multimodal toolkit combining ecological momentary assessment, quantitative observations, and baseline measurements to optimize AI implementation.",
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 23,
+    "source": "npj Digital Medicine",
+    "institutions": [
+      "National Center for Tumor Diseases",
+      "University Hospital Heidelberg",
+      "University Hospital Carl Gustav Carus",
+      "Heidelberg University"
+    ]
+  },
+  {
+    "title": "Human-AI Interactions: Cognitive, Behavioral, and Emotional Impacts",
+    "url": "http://arxiv.org/abs/2510.17753",
+    "authors": [
+      "Celeste Riley",
+      "Omar Alrefai",
+      "Yadira Colunga Reyes",
+      "Eman Hammad"
+    ],
+    "published_date": "2025-10-20",
+    "text": "As stories of human-AI interactions continue to be highlighted in the news and research platforms, the challenges are becoming more pronounced, including potential risks of overreliance, cognitive offloading, social and emotional manipulation, and the nuanced degradation of human agency and judgment. This paper surveys recent research on these issues through the lens of the psychological triad: cognition, behavior, and emotion. Observations seem to suggest that while AI can substantially enhance memory, creativity, and engagement, it also introduces risks such as diminished critical thinking, skill erosion, and increased anxiety. Emotional outcomes are similarly mixed, with AI systems showing promise for support and stress reduction, but raising concerns about dependency, inappropriate attachments, and ethical oversight. This paper aims to underscore the need for responsible and context-aware AI design, highlighting gaps for longitudinal research and grounded evaluation frameworks to balance benefits with emerging human-centric risks.",
+    "highlights": [],
+    "highlight_scores": [],
+    "favicon": null,
+    "cited_by_count": 0,
+    "source": "arXiv (Cornell University)",
+    "institutions": []
+  }
+]


### PR DESCRIPTION
Hello @sabaimran,

In response to #43 issue, I've created a rough benchmark function for 2 search approaches: 1) with Exa search only, and 2) Exa search results enriched with OpenAlex data. A few thoughts I have are:

### Latency
If we define latency as 
> _How long (in seconds) does it take to return the final search results?_

Then you are right that the Exa-only search takes ~1 sec for every run. I tried running the enrichment step with 10 workers, so the time decreased significantly to ~1-3s (originally using a sequential loop would take like ~7-9s). Without this, the original time was ~10s. Though these are just single-point estimates (I will run this across multiple runs and take the averages), they at least give us a feel for how fast or slow things are. From a user perspective, I wouldn't mind waiting 1-3 seconds for better/high-quality search results. You can check out the enrichment results in this [JSON file](https://github.com/khoj-ai/openpaper/commit/54d649a044d3a075c70b0569fd5f072ff5d452be#diff-eac84e37e5d6b9d8c8f58b4a87dcd48a6a0fd84d21432fda1d11f18a662ef5a8).

 <img width="747" height="101" alt="Screenshot 2026-02-21 at 12 19 50 AM" src="https://github.com/user-attachments/assets/096a7071-bd01-4dc7-b1cc-5f532d42c8e6" />

### Edge Cases
- **Getting the DOI from a URL**: For Elsevier, some papers, like this one https://www.sciencedirect.com/science/article/pii/S2215016124000554, do not contain a DOI in the URL but instead another identifier called PII (Publisher Item Identifier). So we need to use CrossRef's `alternative-id:{pii}`. 

- **String Formatting**: some strings are formatted as `Self-Attention Mechanism - an overview | ScienceDirect Topics`, which will cause an error if passed into OpenAlex. This can be fixed by _sanitizing_ the search query before passing it to OA.

### Final Thoughts

In general, I think using on-the-fly OA enrichment with Exa seems like a promising approach! I'm not sure if the almost 2x seconds taken is a big hit given users' perceived slowness. Because I am used to waiting for ChatGPT, Claude, or Perplexity to return results (also about 3-5 secs or more), for me it's not a big deal given that what I care most is the quality of the search. 