### PR TITLE
[Feature] Annotation UI/UX

### DIFF
--- a/client/src/app/(main)/projects/[projectId]/tables/[tableId]/page.tsx
+++ b/client/src/app/(main)/projects/[projectId]/tables/[tableId]/page.tsx
@@ -186,6 +186,7 @@ export default function DataTablePage() {
                                 setUserMessageReferences={() => { }}
                                 setSelectedText={() => { }}
                                 setTooltipPosition={() => { }}
+                                isAnnotating={false}
                                 setIsAnnotating={() => { }}
                                 setIsHighlightInteraction={() => { }}
                                 isHighlightInteraction={false}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -133,7 +133,11 @@ export default function PaperView() {
     const [elapsedTime, setElapsedTime] = useState(0);
 
     const [rightSideFunction, setRightSideFunction] = useState<string>('Overview');
-    const showAnnotationCards = annotationCardsVisible && rightSideFunction !== 'Annotations';
+    const rightSideHidesInlineAnnotationCards =
+        rightSideFunction === 'Annotations' ||
+        rightSideFunction === 'Chat' ||
+        rightSideFunction === 'Audio';
+    const showAnnotationCards = annotationCardsVisible && !rightSideHidesInlineAnnotationCards;
     const [toolset, setToolset] = useState(PaperToolset);
     const initialRsfRef = useRef<string | null>(null);
     const hasInitializedRsf = useRef(false);

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -202,13 +202,7 @@ export default function PaperView() {
     const isMobile = useIsMobile();
     const [mobileView, setMobileView] = useState<'reader' | 'panel'>('reader');
 
-    /** Margin cards stay off while these side panels are open; Read/mobile reader use `annotationCardsVisible` only. */
-    const sidePanelSuppressesInlineCards =
-        rightSideFunction === 'Annotations' ||
-        rightSideFunction === 'Chat' ||
-        rightSideFunction === 'Audio';
-    const showAnnotationCards =
-        annotationCardsVisible && !sidePanelSuppressesInlineCards;
+    const showAnnotationCards = annotationCardsVisible;
 
     const prevRightSideRef = useRef(rightSideFunction);
     useEffect(() => {
@@ -702,6 +696,7 @@ export default function PaperView() {
                                 }
                                 annotationsPanelActive={annotationsPanelActive}
                                 onAnnotateViaSidePanel={onAnnotateViaSidePanel}
+                                sidePanelOpen={rightSideFunction !== 'Read'}
                             />
                         </div>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -197,15 +197,39 @@ export default function PaperView() {
     const isMobile = useIsMobile();
     const [mobileView, setMobileView] = useState<'reader' | 'panel'>('reader');
 
-    const rightSideHidesInlineAnnotationCards =
+    /** Margin cards stay off while these side panels are open; Read/mobile reader use `annotationCardsVisible` only. */
+    const sidePanelSuppressesInlineCards =
         rightSideFunction === 'Annotations' ||
         rightSideFunction === 'Chat' ||
-        rightSideFunction === 'Audio' ||
-        rightSideFunction === 'Read';
-    const hideInlineAnnotationCards =
-        rightSideHidesInlineAnnotationCards ||
-        (isMobile && mobileView === 'reader');
-    const showAnnotationCards = annotationCardsVisible && !hideInlineAnnotationCards;
+        rightSideFunction === 'Audio';
+    const showAnnotationCards =
+        annotationCardsVisible && !sidePanelSuppressesInlineCards;
+
+    const prevRightSideRef = useRef(rightSideFunction);
+    useEffect(() => {
+        if (rightSideFunction === 'Read' && prevRightSideRef.current !== 'Read') {
+            setAnnotationCardsVisible(false);
+        }
+        prevRightSideRef.current = rightSideFunction;
+    }, [rightSideFunction]);
+
+    const prevMobileViewRef = useRef<'reader' | 'panel'>(mobileView);
+    const mobileReaderInitialHideRef = useRef(false);
+    useEffect(() => {
+        if (!isMobile) {
+            prevMobileViewRef.current = mobileView;
+            return;
+        }
+        const prev = prevMobileViewRef.current;
+        if (mobileView === 'reader' && prev === 'panel') {
+            setAnnotationCardsVisible(false);
+        }
+        if (mobileView === 'reader' && !mobileReaderInitialHideRef.current) {
+            mobileReaderInitialHideRef.current = true;
+            setAnnotationCardsVisible(false);
+        }
+        prevMobileViewRef.current = mobileView;
+    }, [isMobile, mobileView]);
 
     if (isMobile) {
         toolset.nav = toolset.nav.filter(tool => tool.name !== 'Read');

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -136,11 +136,6 @@ export default function PaperView() {
 
     const [rightSideFunction, setRightSideFunction] = useState<string>('Overview');
     const annotationsPanelActive = rightSideFunction === 'Annotations';
-    const rightSideHidesInlineAnnotationCards =
-        rightSideFunction === 'Annotations' ||
-        rightSideFunction === 'Chat' ||
-        rightSideFunction === 'Audio';
-    const showAnnotationCards = annotationCardsVisible && !rightSideHidesInlineAnnotationCards;
     useEffect(() => {
         if (rightSideFunction !== 'Annotations') {
             setComposeHighlightId(null);
@@ -201,6 +196,16 @@ export default function PaperView() {
     const [isDragging, setIsDragging] = useState(false);
     const isMobile = useIsMobile();
     const [mobileView, setMobileView] = useState<'reader' | 'panel'>('reader');
+
+    const rightSideHidesInlineAnnotationCards =
+        rightSideFunction === 'Annotations' ||
+        rightSideFunction === 'Chat' ||
+        rightSideFunction === 'Audio' ||
+        rightSideFunction === 'Read';
+    const hideInlineAnnotationCards =
+        rightSideHidesInlineAnnotationCards ||
+        (isMobile && mobileView === 'reader');
+    const showAnnotationCards = annotationCardsVisible && !hideInlineAnnotationCards;
 
     if (isMobile) {
         toolset.nav = toolset.nav.filter(tool => tool.name !== 'Read');
@@ -567,7 +572,7 @@ export default function PaperView() {
                                     removeAnnotation={removeAnnotation}
                                     currentUser={user}
                                     showAnnotationCards={showAnnotationCards}
-                                    onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
+                                    onToggleAnnotationCards={() => setAnnotationCardsVisible((v) => !v)}
                                     annotationsPanelActive={annotationsPanelActive}
                                     onAnnotateViaSidePanel={onAnnotateViaSidePanel}
                                 />
@@ -596,6 +601,8 @@ export default function PaperView() {
                                             rightSideFunction={rightSideFunction}
                                             setRightSideFunction={setRightSideFunction}
                                             PaperToolset={toolset}
+                                            showAnnotationCards={showAnnotationCards}
+                                            onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
                                         />
                                     </>
                                 )}
@@ -661,7 +668,6 @@ export default function PaperView() {
                                 removeAnnotation={removeAnnotation}
                                 currentUser={user}
                                 showAnnotationCards={showAnnotationCards}
-                                onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
                                 annotationsPanelActive={annotationsPanelActive}
                                 onAnnotateViaSidePanel={onAnnotateViaSidePanel}
                             />
@@ -703,6 +709,8 @@ export default function PaperView() {
                                 rightSideFunction={rightSideFunction}
                                 setRightSideFunction={setRightSideFunction}
                                 PaperToolset={toolset}
+                                showAnnotationCards={showAnnotationCards}
+                                onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
                             />
                         </>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -41,8 +41,8 @@ const OverviewTool = {
     icon: Lightbulb,
 }
 
-const FocusTool = {
-    name: "Focus",
+const ReadTool = {
+    name: "Read",
     icon: Focus,
 }
 
@@ -67,7 +67,7 @@ const PaperToolset = {
         OverviewTool,
         AnnotationsTool,
         AudioTool,
-        FocusTool,
+        ReadTool,
     ],
 }
 
@@ -140,7 +140,9 @@ export default function PaperView() {
     // Capture the initial rsf from URL on first render
     useEffect(() => {
         if (initialRsfRef.current === null) {
-            initialRsfRef.current = searchParams.get('rsf')?.toLowerCase() || null;
+            let rsf = searchParams.get('rsf')?.toLowerCase() || null;
+            if (rsf === 'focus') rsf = 'read'; // legacy URL param when tool was named Focus
+            initialRsfRef.current = rsf;
         }
     }, [searchParams]);
 
@@ -187,7 +189,7 @@ export default function PaperView() {
     const [mobileView, setMobileView] = useState<'reader' | 'panel'>('reader');
 
     if (isMobile) {
-        toolset.nav = toolset.nav.filter(tool => tool.name !== 'Focus');
+        toolset.nav = toolset.nav.filter(tool => tool.name !== 'Read');
     }
 
     useEffect(() => {
@@ -528,6 +530,7 @@ export default function PaperView() {
                                     removeAnnotation={removeAnnotation}
                                     currentUser={user}
                                     showAnnotationCards={showAnnotationCards}
+                                    onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
                                 />
                             )}
                         </div>
@@ -554,8 +557,6 @@ export default function PaperView() {
                                             rightSideFunction={rightSideFunction}
                                             setRightSideFunction={setRightSideFunction}
                                             PaperToolset={toolset}
-                                            showAnnotationCards={showAnnotationCards}
-                                            onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
                                         />
                                     </>
                                 )}
@@ -586,7 +587,7 @@ export default function PaperView() {
                 <div
                     className="border-r-2 dark:border-gray-800 border-gray-200 p-0 h-full"
                     style={{
-                        width: rightSideFunction === 'Focus' ? '100%' : `${leftPanelWidth}%`
+                        width: rightSideFunction === 'Read' ? '100%' : `${leftPanelWidth}%`
                     }}
                 >
                     {paperData.file_url && (
@@ -621,13 +622,14 @@ export default function PaperView() {
                                 removeAnnotation={removeAnnotation}
                                 currentUser={user}
                                 showAnnotationCards={showAnnotationCards}
+                                onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
                             />
                         </div>
                     )}
                 </div>
 
                 {/* Resizable Divider */}
-                {rightSideFunction !== 'Focus' && (
+                {rightSideFunction !== 'Read' && (
                     <div
                         className="w-2 bg-background hover:bg-blue-100 dark:hover:bg-blue-400 cursor-col-resize transition-colors duration-200 flex-shrink-0 h-full rounded-2xl"
                         onMouseDown={(e) => {
@@ -640,7 +642,7 @@ export default function PaperView() {
                 {/* Right Side Panel */}
                 <div
                     className="flex flex-row h-full relative"
-                    style={rightSideFunction !== 'Focus' ? { width: `${100 - leftPanelWidth}%` } : { width: 'auto' }}
+                    style={rightSideFunction !== 'Read' ? { width: `${100 - leftPanelWidth}%` } : { width: 'auto' }}
                 >
                     {jobId ? (
                         <div className="flex flex-col h-full w-full">
@@ -660,8 +662,6 @@ export default function PaperView() {
                                 rightSideFunction={rightSideFunction}
                                 setRightSideFunction={setRightSideFunction}
                                 PaperToolset={toolset}
-                                showAnnotationCards={showAnnotationCards}
-                                onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
                             />
                         </>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -108,6 +108,8 @@ export default function PaperView() {
     } = useAnnotations(id);
 
     const [annotationCardsVisible, setAnnotationCardsVisible] = useState(true);
+    /** When Annotations side panel is open, compose first note / reply here instead of margin cards */
+    const [composeHighlightId, setComposeHighlightId] = useState<string | null>(null);
     const [activeCitationKey, setActiveCitationKey] = useState<string | null>(null);
     const [activeCitationMessageIndex, setActiveCitationMessageIndex] = useState<number | null>(null);
     const [explicitSearchTerm, setExplicitSearchTerm] = useState<string | undefined>(undefined);
@@ -133,11 +135,18 @@ export default function PaperView() {
     const [elapsedTime, setElapsedTime] = useState(0);
 
     const [rightSideFunction, setRightSideFunction] = useState<string>('Overview');
+    const annotationsPanelActive = rightSideFunction === 'Annotations';
     const rightSideHidesInlineAnnotationCards =
         rightSideFunction === 'Annotations' ||
         rightSideFunction === 'Chat' ||
         rightSideFunction === 'Audio';
     const showAnnotationCards = annotationCardsVisible && !rightSideHidesInlineAnnotationCards;
+    useEffect(() => {
+        if (rightSideFunction !== 'Annotations') {
+            setComposeHighlightId(null);
+        }
+    }, [rightSideFunction]);
+
     const [toolset, setToolset] = useState(PaperToolset);
     const initialRsfRef = useRef<string | null>(null);
     const hasInitializedRsf = useRef(false);
@@ -310,9 +319,13 @@ export default function PaperView() {
 
     const handleHighlightClick = useCallback((highlight: PaperHighlight) => {
         setActiveHighlight(highlight);
-        // Use search to navigate to the highlight text in the PDF
-        if (highlight.raw_text) {
+        // Position-backed highlights: PdfHighlighterViewer scrolls via scrollToHighlight only.
+        // Do not set explicitSearchTerm — it triggers usePdfSearch goToMatch(0) (first occurrence)
+        // and fights correct alignment when raw_text appears multiple times.
+        if (highlight.raw_text && !highlight.position) {
             setExplicitSearchTerm(highlight.raw_text);
+        } else {
+            setExplicitSearchTerm(undefined);
         }
     }, []);
 
@@ -470,6 +483,25 @@ export default function PaperView() {
         }
     }, [id, paperData]);
 
+    const onAnnotateViaSidePanel = useCallback((payload: { highlightId: string }) => {
+        setComposeHighlightId(payload.highlightId);
+    }, []);
+
+    const onComposeHighlightDismiss = useCallback(
+        (cancelledHighlightId?: string | null) => {
+            setComposeHighlightId(null);
+            setIsAnnotating(false);
+            // End PDF "selected" emphasis when compose closes — otherwise activeHighlightStore
+            // stays set and the paragraph keeps the active (0.4) tint after Save.
+            setActiveHighlight(null);
+            if (cancelledHighlightId == null || cancelledHighlightId === '') return;
+            if (annotations.some((a) => a.highlight_id === cancelledHighlightId)) return;
+            const h = highlights.find((x) => x.id === cancelledHighlightId);
+            if (h) removeHighlight(h);
+        },
+        [annotations, highlights, removeHighlight, setActiveHighlight]
+    );
+
     if (loading) return <PaperViewSkeleton />;
 
     if (!paperData) return <div>Paper not found</div>;
@@ -493,6 +525,9 @@ export default function PaperView() {
         userMessageReferences,
         setUserMessageReferences,
         renderedHighlightPositions,
+        composeHighlightId,
+        onComposeHighlightDismiss,
+        addAnnotation,
     };
 
     if (isMobile) {
@@ -533,6 +568,8 @@ export default function PaperView() {
                                     currentUser={user}
                                     showAnnotationCards={showAnnotationCards}
                                     onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
+                                    annotationsPanelActive={annotationsPanelActive}
+                                    onAnnotateViaSidePanel={onAnnotateViaSidePanel}
                                 />
                             )}
                         </div>
@@ -625,6 +662,8 @@ export default function PaperView() {
                                 currentUser={user}
                                 showAnnotationCards={showAnnotationCards}
                                 onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
+                                annotationsPanelActive={annotationsPanelActive}
+                                onAnnotateViaSidePanel={onAnnotateViaSidePanel}
                             />
                         </div>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import {
     AudioLines,
-    Focus,
     Highlighter,
     Lightbulb,
     MessageCircle,
@@ -42,12 +41,6 @@ const OverviewTool = {
     icon: Lightbulb,
 }
 
-const ReadTool = {
-    name: "Read",
-    label: "Read mode",
-    icon: Focus,
-}
-
 const ChatTool = {
     name: "Chat",
     label: "Show chat",
@@ -72,7 +65,6 @@ const PaperToolset = {
         OverviewTool,
         AnnotationsTool,
         AudioTool,
-        ReadTool,
     ],
 }
 
@@ -174,7 +166,9 @@ export default function PaperView() {
             // Only set from URL on first initialization
             if (!hasInitializedRsf.current) {
                 hasInitializedRsf.current = true;
-                if (rsf && validTools.includes(rsf)) {
+                if (rsf === 'read') {
+                    setRightSideFunction('Read');
+                } else if (rsf && validTools.includes(rsf)) {
                     const toolName = newNav.find(tool => tool.name.toLowerCase() === rsf);
                     setRightSideFunction(toolName ? toolName.name : 'Chat');
                 } else if (hasOverview) {
@@ -203,14 +197,30 @@ export default function PaperView() {
     const [mobileView, setMobileView] = useState<'reader' | 'panel'>('reader');
 
     const showAnnotationCards = annotationCardsVisible;
+    const isReadMode = rightSideFunction === 'Read';
 
+    /** Tracks the last non-Read panel so we can restore it when exiting focus mode. */
+    const lastNonReadFunctionRef = useRef<string>('Chat');
     const prevRightSideRef = useRef(rightSideFunction);
     useEffect(() => {
         if (rightSideFunction === 'Read' && prevRightSideRef.current !== 'Read') {
             setAnnotationCardsVisible(false);
         }
+        if (prevRightSideRef.current !== 'Read') {
+            lastNonReadFunctionRef.current = prevRightSideRef.current;
+        }
         prevRightSideRef.current = rightSideFunction;
     }, [rightSideFunction]);
+
+    const handleToggleReadMode = useCallback(() => {
+        if (isReadMode) {
+            const target = lastNonReadFunctionRef.current;
+            const validTools = toolset.nav.map(t => t.name);
+            setRightSideFunction(validTools.includes(target) ? target : 'Chat');
+        } else {
+            setRightSideFunction('Read');
+        }
+    }, [isReadMode, toolset.nav]);
 
     const prevMobileViewRef = useRef<'reader' | 'panel'>(mobileView);
     const mobileReaderInitialHideRef = useRef(false);
@@ -229,10 +239,6 @@ export default function PaperView() {
         }
         prevMobileViewRef.current = mobileView;
     }, [isMobile, mobileView]);
-
-    if (isMobile) {
-        toolset.nav = toolset.nav.filter(tool => tool.name !== 'Read');
-    }
 
     useEffect(() => {
         if (jobId) {
@@ -697,6 +703,8 @@ export default function PaperView() {
                                 annotationsPanelActive={annotationsPanelActive}
                                 onAnnotateViaSidePanel={onAnnotateViaSidePanel}
                                 sidePanelOpen={rightSideFunction !== 'Read'}
+                                isReadMode={isReadMode}
+                                onToggleReadMode={handleToggleReadMode}
                             />
                         </div>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -64,9 +64,9 @@ const AudioTool = {
 const PaperToolset = {
     nav: [
         OverviewTool,
+        AnnotationsTool,
         ChatTool,
         AudioTool,
-        AnnotationsTool,
         FocusTool,
     ],
 }
@@ -532,7 +532,7 @@ export default function PaperView() {
                     ) : (
                         <div className="w-full h-full">
                             <div
-                                className={`flex flex-row h-full relative ${!jobId ? "pr-[60px]" : ""}`}
+                                className="flex flex-row h-full relative"
                             >
                                 {jobId ? (
                                     <div className="flex flex-col h-full w-full">
@@ -629,7 +629,7 @@ export default function PaperView() {
 
                 {/* Right Side Panel */}
                 <div
-                    className={`flex flex-row h-full relative ${!jobId ? "pr-[60px]" : ""}`}
+                    className="flex flex-row h-full relative"
                     style={rightSideFunction !== 'Focus' ? { width: `${100 - leftPanelWidth}%` } : { width: 'auto' }}
                 >
                     {jobId ? (

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -226,14 +226,18 @@ export default function PaperView() {
     /** Tracks the last non-Read panel so we can restore it when exiting focus mode. */
     const lastNonReadFunctionRef = useRef<string>('Chat');
     const prevRightSideRef = useRef(rightSideFunction);
+    /** Tracks annotation card visibility before entering Read mode so it can be restored on exit. */
+    const preReadAnnotationCardsRef = useRef<boolean>(false);
     useEffect(() => {
         if (rightSideFunction === 'Read' && prevRightSideRef.current !== 'Read') {
-            setAnnotationCardsVisible(false);
+            preReadAnnotationCardsRef.current = annotationCardsVisible;
         }
         if (prevRightSideRef.current !== 'Read') {
             lastNonReadFunctionRef.current = prevRightSideRef.current;
         }
         prevRightSideRef.current = rightSideFunction;
+    // annotationCardsVisible intentionally excluded — only read on transition into Read mode
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [rightSideFunction]);
 
     const handleToggleReadMode = useCallback(() => {
@@ -241,6 +245,7 @@ export default function PaperView() {
             const target = lastNonReadFunctionRef.current;
             const validTools = toolset.nav.map(t => t.name);
             setRightSideFunction(validTools.includes(target) ? target : 'Chat');
+            setAnnotationCardsVisible(preReadAnnotationCardsRef.current);
         } else {
             setRightSideFunction('Read');
         }

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -697,6 +697,9 @@ export default function PaperView() {
                                 removeAnnotation={removeAnnotation}
                                 currentUser={user}
                                 showAnnotationCards={showAnnotationCards}
+                                onToggleAnnotationCards={() =>
+                                    setAnnotationCardsVisible((v) => !v)
+                                }
                                 annotationsPanelActive={annotationsPanelActive}
                                 onAnnotateViaSidePanel={onAnnotateViaSidePanel}
                             />
@@ -738,8 +741,6 @@ export default function PaperView() {
                                 rightSideFunction={rightSideFunction}
                                 setRightSideFunction={setRightSideFunction}
                                 PaperToolset={toolset}
-                                showAnnotationCards={showAnnotationCards}
-                                onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
                             />
                         </>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -4,20 +4,20 @@ import { PdfHighlighterViewer, RenderedHighlightPosition } from '@/components/Pd
 import { Button } from '@/components/ui/button';
 import { fetchFromApi } from '@/lib/api';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 
 import {
-    Highlighter,
-    MessageCircle,
-    Focus,
-    Lightbulb,
     AudioLines,
+    Focus,
+    Highlighter,
+    Lightbulb,
+    MessageCircle,
 } from 'lucide-react';
 import { toast } from "sonner";
 
-import { useHighlighterHighlights } from '@/components/hooks/PdfHighlighterHighlights';
 import { useAnnotations } from '@/components/hooks/PdfAnnotation';
+import { useHighlighterHighlights } from '@/components/hooks/PdfHighlighterHighlights';
 
 import {
     PaperData,
@@ -25,16 +25,16 @@ import {
     PaperUploadJobStatusResponse,
 } from '@/lib/schema';
 
+import { PaperSidebar } from '@/components/PaperSidebar';
 import { PaperStatus, PaperStatusEnum } from '@/components/utils/PdfStatus';
 import { useAuth } from '@/lib/auth';
-import { PaperSidebar } from '@/components/PaperSidebar';
 
 import PaperViewSkeleton from '@/components/PaperViewSkeleton';
 import ReportSkeleton from '@/components/ReportSkeleton';
 
+import { SidePanelContent } from '@/components/SidePanelContent';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Book, Box } from 'lucide-react';
-import { SidePanelContent } from '@/components/SidePanelContent';
 
 const OverviewTool = {
     name: "Overview",
@@ -63,9 +63,9 @@ const AudioTool = {
 
 const PaperToolset = {
     nav: [
+        ChatTool,
         OverviewTool,
         AnnotationsTool,
-        ChatTool,
         AudioTool,
         FocusTool,
     ],

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -107,6 +107,7 @@ export default function PaperView() {
         refreshAnnotations,
     } = useAnnotations(id);
 
+    const [showAnnotationCards, setShowAnnotationCards] = useState(true);
     const [activeCitationKey, setActiveCitationKey] = useState<string | null>(null);
     const [activeCitationMessageIndex, setActiveCitationMessageIndex] = useState<number | null>(null);
     const [explicitSearchTerm, setExplicitSearchTerm] = useState<string | undefined>(undefined);
@@ -524,6 +525,7 @@ export default function PaperView() {
                                     onRefreshUrl={refreshPdfUrl}
                                     addAnnotation={addAnnotation}
                                     currentUser={user}
+                                    showAnnotationCards={showAnnotationCards}
                                 />
                             )}
                         </div>
@@ -550,6 +552,8 @@ export default function PaperView() {
                                             rightSideFunction={rightSideFunction}
                                             setRightSideFunction={setRightSideFunction}
                                             PaperToolset={toolset}
+                                            showAnnotationCards={showAnnotationCards}
+                                            onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
                                         />
                                     </>
                                 )}
@@ -612,6 +616,7 @@ export default function PaperView() {
                                 onRefreshUrl={refreshPdfUrl}
                                 addAnnotation={addAnnotation}
                                 currentUser={user}
+                                showAnnotationCards={showAnnotationCards}
                             />
                         </div>
                     )}
@@ -651,7 +656,10 @@ export default function PaperView() {
                                 rightSideFunction={rightSideFunction}
                                 setRightSideFunction={setRightSideFunction}
                                 PaperToolset={toolset}
-                            />                        </>
+                                showAnnotationCards={showAnnotationCards}
+                                onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
+                            />
+                        </>
                     )}
                 </div>
             </div>

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -199,6 +199,30 @@ export default function PaperView() {
     const showAnnotationCards = annotationCardsVisible;
     const isReadMode = rightSideFunction === 'Read';
 
+    /** Auto-narrow side panel while annotating with a margin card visible.
+     *  Skip when the annotation is routed to the Annotations side panel (no margin card). */
+    const ANNOTATE_MIN_PDF_WIDTH = 70; // %
+    const preAnnotateWidthRef = useRef<number | null>(null);
+    const annotationGoesToSidePanel = !showAnnotationCards && annotationsPanelActive;
+    useEffect(() => {
+        const shouldWiden = isAnnotating && !isReadMode && !annotationGoesToSidePanel;
+        if (shouldWiden && preAnnotateWidthRef.current === null) {
+            // Turn on annotation card visibility so the new card is seen
+            if (!annotationCardsVisible) {
+                setAnnotationCardsVisible(true);
+            }
+            preAnnotateWidthRef.current = leftPanelWidth;
+            if (leftPanelWidth < ANNOTATE_MIN_PDF_WIDTH) {
+                setLeftPanelWidth(ANNOTATE_MIN_PDF_WIDTH);
+            }
+        } else if (!shouldWiden && preAnnotateWidthRef.current !== null) {
+            setLeftPanelWidth(preAnnotateWidthRef.current);
+            preAnnotateWidthRef.current = null;
+        }
+    // leftPanelWidth, annotationCardsVisible intentionally excluded — only read on transition
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isAnnotating, isReadMode, annotationGoesToSidePanel]);
+
     /** Tracks the last non-Read panel so we can restore it when exiting focus mode. */
     const lastNonReadFunctionRef = useRef<string>('Chat');
     const prevRightSideRef = useRef(rightSideFunction);
@@ -662,7 +686,8 @@ export default function PaperView() {
                 <div
                     className="border-r-2 dark:border-gray-800 border-gray-200 p-0 h-full"
                     style={{
-                        width: rightSideFunction === 'Read' ? '100%' : `${leftPanelWidth}%`
+                        width: rightSideFunction === 'Read' ? '100%' : `${leftPanelWidth}%`,
+                        transition: isDragging ? 'none' : 'width 300ms ease',
                     }}
                 >
                     {paperData.file_url && (
@@ -724,7 +749,10 @@ export default function PaperView() {
                 {/* Right Side Panel */}
                 <div
                     className="flex flex-row h-full relative"
-                    style={rightSideFunction !== 'Read' ? { width: `${100 - leftPanelWidth}%` } : { width: 'auto' }}
+                    style={{
+                        width: rightSideFunction !== 'Read' ? `${100 - leftPanelWidth}%` : 'auto',
+                        transition: isDragging ? 'none' : 'width 300ms ease',
+                    }}
                 >
                     {jobId ? (
                         <div className="flex flex-col h-full w-full">

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -107,7 +107,7 @@ export default function PaperView() {
         refreshAnnotations,
     } = useAnnotations(id);
 
-    const [showAnnotationCards, setShowAnnotationCards] = useState(true);
+    const [annotationCardsVisible, setAnnotationCardsVisible] = useState(true);
     const [activeCitationKey, setActiveCitationKey] = useState<string | null>(null);
     const [activeCitationMessageIndex, setActiveCitationMessageIndex] = useState<number | null>(null);
     const [explicitSearchTerm, setExplicitSearchTerm] = useState<string | undefined>(undefined);
@@ -133,6 +133,7 @@ export default function PaperView() {
     const [elapsedTime, setElapsedTime] = useState(0);
 
     const [rightSideFunction, setRightSideFunction] = useState<string>('Overview');
+    const showAnnotationCards = annotationCardsVisible && rightSideFunction !== 'Annotations';
     const [toolset, setToolset] = useState(PaperToolset);
     const initialRsfRef = useRef<string | null>(null);
     const hasInitializedRsf = useRef(false);
@@ -475,10 +476,7 @@ export default function PaperView() {
         annotations,
         highlights,
         handleHighlightClick,
-        addAnnotation,
         activeHighlight,
-        updateAnnotation,
-        removeAnnotation,
         isSharing,
         handleShare,
         handleUnshare,
@@ -530,7 +528,7 @@ export default function PaperView() {
                                     removeAnnotation={removeAnnotation}
                                     currentUser={user}
                                     showAnnotationCards={showAnnotationCards}
-                                    onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
+                                    onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
                                 />
                             )}
                         </div>
@@ -622,7 +620,7 @@ export default function PaperView() {
                                 removeAnnotation={removeAnnotation}
                                 currentUser={user}
                                 showAnnotationCards={showAnnotationCards}
-                                onToggleAnnotationCards={() => setShowAnnotationCards(v => !v)}
+                                onToggleAnnotationCards={() => setAnnotationCardsVisible(v => !v)}
                             />
                         </div>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -112,7 +112,7 @@ export default function PaperView() {
         refreshAnnotations,
     } = useAnnotations(id);
 
-    const [annotationCardsVisible, setAnnotationCardsVisible] = useState(true);
+    const [annotationCardsVisible, setAnnotationCardsVisible] = useState(false);
     /** When Annotations side panel is open, compose first note / reply here instead of margin cards */
     const [composeHighlightId, setComposeHighlightId] = useState<string | null>(null);
     const [activeCitationKey, setActiveCitationKey] = useState<string | null>(null);

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -200,11 +200,6 @@ export default function PaperView() {
         }
     }, [jobId]);
 
-    useEffect(() => {
-        if (isAnnotating) {
-            setRightSideFunction('Annotations');
-        }
-    }, [isAnnotating]);
 
     useEffect(() => {
         if (!jobId) {
@@ -508,6 +503,7 @@ export default function PaperView() {
                                     setUserMessageReferences={setUserMessageReferences}
                                     setSelectedText={setSelectedText}
                                     setTooltipPosition={setTooltipPosition}
+                                    isAnnotating={isAnnotating}
                                     setIsAnnotating={setIsAnnotating}
                                     setIsHighlightInteraction={setIsHighlightInteraction}
                                     isHighlightInteraction={isHighlightInteraction}
@@ -526,6 +522,8 @@ export default function PaperView() {
                                     paperStatus={paperData.status}
                                     onOverlaysCreated={handleOverlaysCreated}
                                     onRefreshUrl={refreshPdfUrl}
+                                    addAnnotation={addAnnotation}
+                                    currentUser={user}
                                 />
                             )}
                         </div>
@@ -593,6 +591,7 @@ export default function PaperView() {
                                 setUserMessageReferences={setUserMessageReferences}
                                 setSelectedText={setSelectedText}
                                 setTooltipPosition={setTooltipPosition}
+                                isAnnotating={isAnnotating}
                                 setIsAnnotating={setIsAnnotating}
                                 setIsHighlightInteraction={setIsHighlightInteraction}
                                 isHighlightInteraction={isHighlightInteraction}
@@ -611,6 +610,8 @@ export default function PaperView() {
                                 paperStatus={paperData.status}
                                 onOverlaysCreated={handleOverlaysCreated}
                                 onRefreshUrl={refreshPdfUrl}
+                                addAnnotation={addAnnotation}
+                                currentUser={user}
                             />
                         </div>
                     )}

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -524,6 +524,8 @@ export default function PaperView() {
                                     onOverlaysCreated={handleOverlaysCreated}
                                     onRefreshUrl={refreshPdfUrl}
                                     addAnnotation={addAnnotation}
+                                    updateAnnotation={updateAnnotation}
+                                    removeAnnotation={removeAnnotation}
                                     currentUser={user}
                                     showAnnotationCards={showAnnotationCards}
                                 />
@@ -615,6 +617,8 @@ export default function PaperView() {
                                 onOverlaysCreated={handleOverlaysCreated}
                                 onRefreshUrl={refreshPdfUrl}
                                 addAnnotation={addAnnotation}
+                                updateAnnotation={updateAnnotation}
+                                removeAnnotation={removeAnnotation}
                                 currentUser={user}
                                 showAnnotationCards={showAnnotationCards}
                             />

--- a/client/src/app/(paper)/paper/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/[id]/page.tsx
@@ -38,26 +38,31 @@ import { Book, Box } from 'lucide-react';
 
 const OverviewTool = {
     name: "Overview",
+    label: "Overview",
     icon: Lightbulb,
 }
 
 const ReadTool = {
     name: "Read",
+    label: "Read mode",
     icon: Focus,
 }
 
 const ChatTool = {
     name: "Chat",
+    label: "Show chat",
     icon: MessageCircle,
 }
 
 const AnnotationsTool = {
     name: "Annotations",
+    label: "All annotations",
     icon: Highlighter,
 }
 
 const AudioTool = {
     name: "Audio",
+    label: "Audio",
     icon: AudioLines,
 }
 

--- a/client/src/app/(paper)/paper/layout.tsx
+++ b/client/src/app/(paper)/paper/layout.tsx
@@ -16,8 +16,6 @@ import Link from "next/link";
 import { ManageProjectsButton } from "@/components/ManageProjectsButton";
 import { MobilePaperMenu } from "@/components/MobilePaperMenu";
 import { CitePaperButton } from "@/components/CitePaperButton";
-import { PaperHeaderExtrasMenu } from "@/components/PaperHeaderExtrasMenu";
-
 const geistSans = Geist({
 	variable: "--font-geist-sans",
 	subsets: ["latin"],
@@ -106,7 +104,6 @@ export default function RootLayout({
 									<ManageProjectsButton />
 									<CitePaperButton />
 									<SharePaperButton />
-									<PaperHeaderExtrasMenu />
 								</div>
 									{/* Mobile menu */}
 									<MobilePaperMenu />

--- a/client/src/app/(paper)/paper/layout.tsx
+++ b/client/src/app/(paper)/paper/layout.tsx
@@ -9,14 +9,14 @@ import { AuthProvider } from "@/lib/auth";
 import { Toaster } from "@/components/ui/sonner";
 import { PostHogProvider, ThemeProvider } from "@/lib/providers";
 import { SharePaperButton } from '@/components/SharePaperButton';
-import { CitationGraphButton } from '@/components/CitationGraphButton';
-import { ImportPaperButton } from '@/components/ImportPaperButton';
 
 import { SidebarController } from "@/components/utils/SidebarAutoCollapse";
 import Image from "next/image";
 import Link from "next/link";
 import { ManageProjectsButton } from "@/components/ManageProjectsButton";
 import { MobilePaperMenu } from "@/components/MobilePaperMenu";
+import { CitePaperButton } from "@/components/CitePaperButton";
+import { PaperHeaderExtrasMenu } from "@/components/PaperHeaderExtrasMenu";
 
 const geistSans = Geist({
 	variable: "--font-geist-sans",
@@ -103,10 +103,10 @@ export default function RootLayout({
 										</Link>
 									{/* Desktop buttons */}
 								<div className="hidden md:flex items-center gap-2">
-									<ImportPaperButton />
 									<ManageProjectsButton />
-									<CitationGraphButton />
+									<CitePaperButton />
 									<SharePaperButton />
+									<PaperHeaderExtrasMenu />
 								</div>
 									{/* Mobile menu */}
 									<MobilePaperMenu />

--- a/client/src/app/(paper)/paper/layout.tsx
+++ b/client/src/app/(paper)/paper/layout.tsx
@@ -9,7 +9,6 @@ import { AuthProvider } from "@/lib/auth";
 import { Toaster } from "@/components/ui/sonner";
 import { PostHogProvider, ThemeProvider } from "@/lib/providers";
 import { SharePaperButton } from '@/components/SharePaperButton';
-import { CitePaperButton } from '@/components/CitePaperButton';
 import { CitationGraphButton } from '@/components/CitationGraphButton';
 import { ImportPaperButton } from '@/components/ImportPaperButton';
 
@@ -103,13 +102,12 @@ export default function RootLayout({
 											<span className="text-sm font-semibold">Open Paper</span>
 										</Link>
 									{/* Desktop buttons */}
-									<div className="hidden md:flex items-center gap-2">
-										<ImportPaperButton />
-										<ManageProjectsButton />
-										<CitationGraphButton />
-										<CitePaperButton />
-										<SharePaperButton />
-									</div>
+								<div className="hidden md:flex items-center gap-2">
+									<ImportPaperButton />
+									<ManageProjectsButton />
+									<CitationGraphButton />
+									<SharePaperButton />
+								</div>
 									{/* Mobile menu */}
 									<MobilePaperMenu />
 									</header>

--- a/client/src/app/(paper)/paper/share/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/share/[id]/page.tsx
@@ -320,19 +320,6 @@ export default function SharedPaperView() {
         fetchConversation();
     }, [shareId]);
 
-    if (loading) {
-        return <div className="flex justify-center items-center h-screen">Loading shared paper...</div>;
-    }
-
-    if (error) {
-        return <div className="flex justify-center items-center h-screen text-red-500">{error}</div>;
-    }
-
-    if (!paperData) {
-        return <div className="flex justify-center items-center h-screen">Shared paper data not found.</div>;
-    }
-
-
     const refreshPdfUrl = useCallback(async (): Promise<string | null> => {
         try {
             const response: SharedPaper = await fetchFromApi(`/api/paper/share?id=${shareId}`);
@@ -348,6 +335,18 @@ export default function SharedPaperView() {
     }, [shareId]);
 
     const heightClass = isMobile ? "h-[calc(100vh-128px)]" : "h-[calc(100vh-64px)]";
+
+    if (loading) {
+        return <div className="flex justify-center items-center h-screen">Loading shared paper...</div>;
+    }
+
+    if (error) {
+        return <div className="flex justify-center items-center h-screen text-red-500">{error}</div>;
+    }
+
+    if (!paperData) {
+        return <div className="flex justify-center items-center h-screen">Shared paper data not found.</div>;
+    }
 
 
     if (isMobile) {

--- a/client/src/app/(paper)/paper/share/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/share/[id]/page.tsx
@@ -375,6 +375,7 @@ export default function SharedPaperView() {
                                     onRefreshUrl={refreshPdfUrl}
                                     currentUser={owner ?? null}
                                     showAnnotationCards={showAnnotationCards}
+                                    onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                                 />
                             ) : (
                                 <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>
@@ -445,8 +446,6 @@ export default function SharedPaperView() {
                                 rightSideFunction={rightSideFunction}
                                 setRightSideFunction={setRightSideFunction}
                                 PaperToolset={dynamicPaperToolset}
-                                showAnnotationCards={showAnnotationCards}
-                                onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                             />
                         </div>
                     )}
@@ -497,6 +496,7 @@ export default function SharedPaperView() {
                             onRefreshUrl={refreshPdfUrl}
                             currentUser={owner ?? null}
                             showAnnotationCards={showAnnotationCards}
+                            onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                         />
                     ) : (
                         <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>
@@ -571,8 +571,6 @@ export default function SharedPaperView() {
                         rightSideFunction={rightSideFunction}
                         setRightSideFunction={setRightSideFunction}
                         PaperToolset={dynamicPaperToolset}
-                        showAnnotationCards={showAnnotationCards}
-                        onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                     />
                 </div>
             </div>

--- a/client/src/app/(paper)/paper/share/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/share/[id]/page.tsx
@@ -54,11 +54,11 @@ export default function SharedPaperView() {
 
     const dynamicPaperToolset = useMemo(() => {
         const navItems = [
-            { name: 'Chat', icon: MessageCircle },
-            { name: 'Annotations', icon: Highlighter },
+            { name: 'Chat', label: 'Show chat', icon: MessageCircle },
+            { name: 'Annotations', label: 'All annotations', icon: Highlighter },
         ];
         if (paperData?.summary) {
-            navItems.unshift({ name: 'Overview', icon: Lightbulb });
+            navItems.unshift({ name: 'Overview', label: 'Overview', icon: Lightbulb });
         }
         return { nav: navItems };
     }, [paperData?.summary]);

--- a/client/src/app/(paper)/paper/share/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/share/[id]/page.tsx
@@ -44,6 +44,7 @@ export default function SharedPaperView() {
     const [activeCitationKey, setActiveCitationKey] = useState<string | null>(null);
     const [activeCitationMessageIndex, setActiveCitationMessageIndex] = useState<number | null>(null);
     const [explicitSearchTerm, setExplicitSearchTerm] = useState<string>();
+    const [showAnnotationCards, setShowAnnotationCards] = useState(true);
 
     const dynamicPaperToolset = useMemo(() => {
         const navItems = [
@@ -357,6 +358,7 @@ export default function SharedPaperView() {
                                     setUserMessageReferences={() => { }}
                                     setSelectedText={() => { }}
                                     setTooltipPosition={() => { }}
+                                    isAnnotating={false}
                                     setIsAnnotating={() => { }}
                                     setIsHighlightInteraction={() => { }}
                                     isHighlightInteraction={false}
@@ -369,8 +371,10 @@ export default function SharedPaperView() {
                                     loadHighlights={async () => { }}
                                     removeHighlight={() => { }}
                                     renderAnnotations={() => { }}
-                                    annotations={[]}
+                                    annotations={annotations}
                                     onRefreshUrl={refreshPdfUrl}
+                                    currentUser={owner ?? null}
+                                    showAnnotationCards={showAnnotationCards}
                                 />
                             ) : (
                                 <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>
@@ -441,6 +445,8 @@ export default function SharedPaperView() {
                                 rightSideFunction={rightSideFunction}
                                 setRightSideFunction={setRightSideFunction}
                                 PaperToolset={dynamicPaperToolset}
+                                showAnnotationCards={showAnnotationCards}
+                                onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                             />
                         </div>
                     )}
@@ -475,6 +481,7 @@ export default function SharedPaperView() {
                             setSelectedText={() => { }}
                             setTooltipPosition={() => { }}
                             explicitSearchTerm={explicitSearchTerm}
+                            isAnnotating={false}
                             setIsAnnotating={() => { }}
                             setIsHighlightInteraction={() => { }}
                             isHighlightInteraction={false}
@@ -486,8 +493,10 @@ export default function SharedPaperView() {
                             loadHighlights={async () => { }}
                             removeHighlight={() => { }}
                             renderAnnotations={() => { }}
-                            annotations={[]}
+                            annotations={annotations}
                             onRefreshUrl={refreshPdfUrl}
+                            currentUser={owner ?? null}
+                            showAnnotationCards={showAnnotationCards}
                         />
                     ) : (
                         <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>
@@ -562,6 +571,8 @@ export default function SharedPaperView() {
                         rightSideFunction={rightSideFunction}
                         setRightSideFunction={setRightSideFunction}
                         PaperToolset={dynamicPaperToolset}
+                        showAnnotationCards={showAnnotationCards}
+                        onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                     />
                 </div>
             </div>

--- a/client/src/app/(paper)/paper/share/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/share/[id]/page.tsx
@@ -504,6 +504,9 @@ export default function SharedPaperView() {
                             onRefreshUrl={refreshPdfUrl}
                             currentUser={owner ?? null}
                             showAnnotationCards={showAnnotationCards}
+                            onToggleAnnotationCards={() =>
+                                setShowAnnotationCards((v) => !v)
+                            }
                         />
                     ) : (
                         <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>
@@ -578,8 +581,6 @@ export default function SharedPaperView() {
                         rightSideFunction={rightSideFunction}
                         setRightSideFunction={setRightSideFunction}
                         PaperToolset={dynamicPaperToolset}
-                        showAnnotationCards={showAnnotationCards}
-                        onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                     />
                 </div>
             </div>

--- a/client/src/app/(paper)/paper/share/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/share/[id]/page.tsx
@@ -382,6 +382,7 @@ export default function SharedPaperView() {
                                     currentUser={owner ?? null}
                                     showAnnotationCards={showAnnotationCards}
                                     onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
+                                    sidePanelOpen
                                 />
                             ) : (
                                 <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>
@@ -507,6 +508,7 @@ export default function SharedPaperView() {
                             onToggleAnnotationCards={() =>
                                 setShowAnnotationCards((v) => !v)
                             }
+                            sidePanelOpen
                         />
                     ) : (
                         <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>

--- a/client/src/app/(paper)/paper/share/[id]/page.tsx
+++ b/client/src/app/(paper)/paper/share/[id]/page.tsx
@@ -5,7 +5,13 @@ import { useParams } from 'next/navigation';
 import { PdfHighlighterViewer } from '@/components/PdfHighlighterViewer';
 import { AnnotationsView } from '@/components/AnnotationsView';
 import { fetchFromApi } from '@/lib/api';
-import { PaperData, PaperHighlight, PaperHighlightAnnotation, ChatMessage, SharedPaper } from '@/lib/schema';
+import {
+    PaperData,
+    PaperHighlight,
+    PaperHighlightAnnotation,
+    ChatMessage,
+    SharedPaper,
+} from '@/lib/schema';
 import PaperMetadata from '@/components/PaperMetadata';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { Book, Box, User } from 'lucide-react';
@@ -446,6 +452,8 @@ export default function SharedPaperView() {
                                 rightSideFunction={rightSideFunction}
                                 setRightSideFunction={setRightSideFunction}
                                 PaperToolset={dynamicPaperToolset}
+                                showAnnotationCards={showAnnotationCards}
+                                onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                             />
                         </div>
                     )}
@@ -496,7 +504,6 @@ export default function SharedPaperView() {
                             onRefreshUrl={refreshPdfUrl}
                             currentUser={owner ?? null}
                             showAnnotationCards={showAnnotationCards}
-                            onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                         />
                     ) : (
                         <div className="flex justify-center items-center h-full">PDF could not be loaded.</div>
@@ -571,6 +578,8 @@ export default function SharedPaperView() {
                         rightSideFunction={rightSideFunction}
                         setRightSideFunction={setRightSideFunction}
                         PaperToolset={dynamicPaperToolset}
+                        showAnnotationCards={showAnnotationCards}
+                        onToggleAnnotationCards={() => setShowAnnotationCards((v) => !v)}
                     />
                 </div>
             </div>

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -317,3 +317,19 @@
 	border-radius: 2px;
 	pointer-events: none;
 }
+
+/*
+ * Zoom: highlight rects jump every layout pass (library viewport math + DOM overlays from search/text-match).
+ * Parent gets pdf-zoom-layout-pending until pagerendered quiets — see PdfHighlighterViewer.
+ */
+/* No opacity transition: fading 0→1 can run over frames where highlight rects are still wrong. */
+.pdf-zoom-layout-pending .PdfHighlighter__highlight-layer {
+	opacity: 0 !important;
+	pointer-events: none !important;
+}
+
+.pdf-zoom-layout-pending .text-match-highlight-overlay,
+.pdf-zoom-layout-pending .search-highlight-overlay {
+	opacity: 0 !important;
+	pointer-events: none !important;
+}

--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -333,3 +333,11 @@
 	opacity: 0 !important;
 	pointer-events: none !important;
 }
+
+/*
+ * Left-align PDF pages when the side panel is open and inline annotation cards
+ * are visible, reclaiming the left negative space for margin cards on the right.
+ */
+.pdf-align-left .pdfViewer .page {
+	margin-left: 0 !important;
+}

--- a/client/src/components/Annotation.tsx
+++ b/client/src/components/Annotation.tsx
@@ -1,12 +1,12 @@
-import React, { useState } from 'react';
-import { Check, File, Pencil, Trash2, User as UserIcon, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
-import { PaperHighlightAnnotation } from '@/lib/schema';
-import { HighlightColor } from '@/lib/schema';
 import { BasicUser } from '@/lib/auth';
+import { HighlightColor, PaperHighlightAnnotation } from '@/lib/schema';
 import { formatDate } from '@/lib/utils';
+import { Check, File, Pencil, Trash2, User as UserIcon, X } from 'lucide-react';
+import React, { useState } from 'react';
 
+// Map highlight color names to bubble background + border classes for annotation notes in the side panel
 const BUBBLE_BG_MAP: Record<HighlightColor, string> = {
     yellow: "bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-800",
     green:  "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-800",

--- a/client/src/components/Annotation.tsx
+++ b/client/src/components/Annotation.tsx
@@ -2,7 +2,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { BasicUser } from '@/lib/auth';
 import { HighlightColor, PaperHighlightAnnotation } from '@/lib/schema';
-import { formatDate } from '@/lib/utils';
+import { formatAnnotationDate } from '@/lib/utils';
 import { Check, File, Pencil, Trash2, User as UserIcon, X } from 'lucide-react';
 import React, { useState } from 'react';
 
@@ -76,7 +76,7 @@ export default function Annotation({
                         {isAI ? 'Open Paper' : user?.name || 'User'}
                     </span>
                     <span className="text-xs text-muted-foreground">
-                        {formatDate(annotation.created_at)}
+                        {formatAnnotationDate(annotation.created_at)}
                     </span>
                 </div>
 
@@ -128,7 +128,7 @@ export default function Annotation({
                     {isAI ? 'Open Paper' : user?.name || 'User'}
                 </span>
                 <span className="text-xs text-muted-foreground">
-                    {formatDate(annotation.created_at)}
+                    {formatAnnotationDate(annotation.created_at)}
                 </span>
 
                 {!readonly && removeAnnotation && updateAnnotation && !isAI && (

--- a/client/src/components/Annotation.tsx
+++ b/client/src/components/Annotation.tsx
@@ -68,7 +68,7 @@ export default function Annotation({
 
     if (isEditing && !readonly) {
         return (
-            <div>
+            <div className="w-full min-w-0">
                 {/* Avatar row */}
                 <div className="flex items-center gap-2">
                     {avatarEl}
@@ -80,33 +80,36 @@ export default function Annotation({
                     </span>
                 </div>
 
-                <Textarea
-                    value={editedContent}
-                    onChange={(e) => setEditedContent(e.target.value)}
-                    className="ml-10 min-h-[60px] text-sm mt-2 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-foreground focus-visible:border-foreground"
-                    onClick={(e) => e.stopPropagation()}
-                    autoFocus
-                    placeholder="Write your annotation..."
-                />
+                {/* Indent to align with name, but use padding so width stays within container */}
+                <div className="pl-10 mt-2">
+                    <Textarea
+                        value={editedContent}
+                        onChange={(e) => setEditedContent(e.target.value)}
+                        className="w-full min-h-[60px] text-sm focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-foreground focus-visible:border-foreground"
+                        onClick={(e) => e.stopPropagation()}
+                        autoFocus
+                        placeholder="Write your annotation..."
+                    />
 
-                <div className="flex items-center justify-end gap-1 mt-1">
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={handleCancel}
-                        className="h-7 text-xs text-muted-foreground hover:text-foreground"
-                    >
-                        <X size={12} className="mr-1" />
-                        Cancel
-                    </Button>
-                    <Button
-                        size="sm"
-                        onClick={handleSave}
-                        className="h-7 text-xs"
-                    >
-                        <Check size={12} className="mr-1" />
-                        Save
-                    </Button>
+                    <div className="flex items-center justify-end gap-1 mt-1">
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={handleCancel}
+                            className="h-7 text-xs text-muted-foreground hover:text-foreground"
+                        >
+                            <X size={12} className="mr-1" />
+                            Cancel
+                        </Button>
+                        <Button
+                            size="sm"
+                            onClick={handleSave}
+                            className="h-7 text-xs"
+                        >
+                            <Check size={12} className="mr-1" />
+                            Save
+                        </Button>
+                    </div>
                 </div>
             </div>
         );

--- a/client/src/components/Annotation.tsx
+++ b/client/src/components/Annotation.tsx
@@ -83,7 +83,7 @@ export default function Annotation({
                 <Textarea
                     value={editedContent}
                     onChange={(e) => setEditedContent(e.target.value)}
-                    className="min-h-[60px] text-sm mt-2"
+                    className="ml-10 min-h-[60px] text-sm mt-2 focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-foreground focus-visible:border-foreground"
                     onClick={(e) => e.stopPropagation()}
                     autoFocus
                     placeholder="Write your annotation..."

--- a/client/src/components/Annotation.tsx
+++ b/client/src/components/Annotation.tsx
@@ -3,11 +3,21 @@ import { Check, File, Pencil, Trash2, User as UserIcon, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { PaperHighlightAnnotation } from '@/lib/schema';
+import { HighlightColor } from '@/lib/schema';
 import { BasicUser } from '@/lib/auth';
 import { formatDate } from '@/lib/utils';
 
+const BUBBLE_BG_MAP: Record<HighlightColor, string> = {
+    yellow: "bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-800",
+    green:  "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-800",
+    blue:   "bg-blue-50 border-blue-200 dark:bg-blue-950/30 dark:border-blue-800",
+    pink:   "bg-pink-50 border-pink-200 dark:bg-pink-950/30 dark:border-pink-800",
+    purple: "bg-purple-50 border-purple-200 dark:bg-purple-950/30 dark:border-purple-800",
+};
+
 interface AnnotationProps {
     annotation: PaperHighlightAnnotation;
+    highlightColor?: HighlightColor;
     user?: BasicUser;
     removeAnnotation?: (annotationId: string) => void;
     updateAnnotation?: (annotationId: string, content: string) => void;
@@ -16,6 +26,7 @@ interface AnnotationProps {
 
 export default function Annotation({
     annotation,
+    highlightColor = 'blue',
     user,
     removeAnnotation,
     updateAnnotation,
@@ -25,6 +36,8 @@ export default function Annotation({
     const [editedContent, setEditedContent] = useState(annotation.content);
     const [isHovered, setIsHovered] = useState(false);
     const isAI = annotation.role === 'assistant';
+
+    const bubbleClass = BUBBLE_BG_MAP[highlightColor] ?? BUBBLE_BG_MAP['blue'];
 
     const handleSave = async (e: React.MouseEvent) => {
         e.stopPropagation();
@@ -40,29 +53,37 @@ export default function Annotation({
         setIsEditing(false);
     };
 
+    const avatarEl = (
+        <div className={`w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden ${isAI ? 'bg-blue-100 dark:bg-blue-900' : 'bg-muted'}`}>
+            {isAI ? (
+                <File size={14} className="text-blue-500" />
+            ) : user?.picture ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
+            ) : (
+                <UserIcon size={14} className="text-muted-foreground" />
+            )}
+        </div>
+    );
+
     if (isEditing && !readonly) {
         return (
-            <div className="border-l border-muted pl-2 py-1">
-                <div className="flex items-center gap-1.5 mb-1">
-                    <div className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 ${isAI
-                        ? 'bg-blue-100 dark:bg-blue-900'
-                        : 'bg-muted'
-                        }`}>
-                        {isAI ? (
-                            <File size={10} className="text-blue-500" />
-                        ) : (
-                            <UserIcon size={10} className="text-muted-foreground" />
-                        )}
-                    </div>
-                    <span className="text-xs font-medium text-foreground">
+            <div>
+                {/* Avatar row */}
+                <div className="flex items-center gap-2">
+                    {avatarEl}
+                    <span className="text-sm font-medium text-foreground">
                         {isAI ? 'Open Paper' : user?.name || 'User'}
+                    </span>
+                    <span className="text-xs text-muted-foreground">
+                        {formatDate(annotation.created_at)}
                     </span>
                 </div>
 
                 <Textarea
                     value={editedContent}
                     onChange={(e) => setEditedContent(e.target.value)}
-                    className="min-h-[60px] text-sm"
+                    className="min-h-[60px] text-sm mt-2"
                     onClick={(e) => e.stopPropagation()}
                     autoFocus
                     placeholder="Write your annotation..."
@@ -93,34 +114,20 @@ export default function Annotation({
 
     return (
         <div
-            className="group border-l border-muted pl-2 py-1"
+            className="group"
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
         >
-            <div className="flex items-center gap-1.5">
-                {/* Avatar */}
-                <div className={`w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden ${isAI
-                    ? 'bg-blue-100 dark:bg-blue-900'
-                    : 'bg-muted'
-                    }`}>
-                    {isAI ? (
-                        <File size={10} className="text-blue-500" />
-                    ) : user?.picture ? (
-                        // eslint-disable-next-line @next/next/no-img-element
-                        <img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
-                    ) : (
-                        <UserIcon size={10} className="text-muted-foreground" />
-                    )}
-                </div>
-
-                <span className="text-xs font-medium text-foreground">
+            {/* Avatar row: avatar + name + timestamp + action buttons */}
+            <div className="flex items-center gap-2">
+                {avatarEl}
+                <span className="text-sm font-medium text-foreground">
                     {isAI ? 'Open Paper' : user?.name || 'User'}
                 </span>
-                <span className="text-[10px] text-muted-foreground">
+                <span className="text-xs text-muted-foreground">
                     {formatDate(annotation.created_at)}
                 </span>
 
-                {/* Action buttons */}
                 {!readonly && removeAnnotation && updateAnnotation && !isAI && (
                     <div className={`flex items-center gap-0.5 ml-auto transition-opacity ${isHovered ? 'opacity-100' : 'opacity-0'}`}>
                         <button
@@ -141,9 +148,10 @@ export default function Annotation({
                 )}
             </div>
 
-            <p className="text-sm text-foreground leading-snug mt-0.5 whitespace-pre-wrap">
+            {/* Annotation note bubble — indented to align with the name */}
+            <div className={`ml-10 border rounded-tr-lg rounded-bl-lg rounded-br-lg p-3 mt-2 text-sm text-foreground leading-snug whitespace-pre-wrap ${bubbleClass}`}>
                 {annotation.content}
-            </p>
+            </div>
         </div>
     );
 }

--- a/client/src/components/AnnotationHoverCard.tsx
+++ b/client/src/components/AnnotationHoverCard.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { createPortal } from "react-dom";
+import { useMemo } from "react";
+import { File, User as UserIcon } from "lucide-react";
+import { BasicUser } from "@/lib/auth";
+import { PaperHighlightAnnotation } from "@/lib/schema";
+import { formatAnnotationDate } from "@/lib/utils";
+
+const CARD_WIDTH = 280;
+const CARD_MAX_HEIGHT = 320;
+const VIEWPORT_PADDING = 8;
+
+interface AnnotationHoverCardProps {
+    annotations: PaperHighlightAnnotation[];
+    position: { x: number; y: number };
+    user: BasicUser | null;
+}
+
+export function AnnotationHoverCard({
+    annotations,
+    position,
+    user,
+}: AnnotationHoverCardProps) {
+    if (annotations.length === 0) return null;
+
+    const sorted = useMemo(
+        () =>
+            [...annotations].sort(
+                (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+            ),
+        [annotations]
+    );
+
+    // Clamp so the card stays within the viewport
+    const left = Math.min(position.x, window.innerWidth - CARD_WIDTH - VIEWPORT_PADDING);
+    const top = Math.min(position.y, window.innerHeight - CARD_MAX_HEIGHT - VIEWPORT_PADDING);
+
+    return createPortal(
+        <div
+            data-annotation-hover-card=""
+            className="fixed z-50 w-[280px] max-h-[320px] overflow-y-auto rounded-xl shadow-lg border border-border bg-background p-3 flex flex-col gap-3 pointer-events-none"
+            style={{ left, top }}
+        >
+            {sorted.map((ann) => {
+                const isAI = ann.role === "assistant";
+                return (
+                    <div key={ann.id} className="flex flex-col gap-1.5">
+                        <div className="flex items-center gap-2">
+                            <div
+                                className={`w-6 h-6 rounded-full flex-shrink-0 flex items-center justify-center overflow-hidden ${
+                                    isAI ? "bg-blue-100 dark:bg-blue-900" : "bg-muted"
+                                }`}
+                            >
+                                {isAI ? (
+                                    <File size={12} className="text-blue-500" />
+                                ) : user?.picture ? (
+                                    // eslint-disable-next-line @next/next/no-img-element
+                                    <img
+                                        src={user.picture}
+                                        alt={user.name}
+                                        className="w-full h-full object-cover"
+                                    />
+                                ) : (
+                                    <UserIcon size={12} className="text-muted-foreground" />
+                                )}
+                            </div>
+                            <span className="text-xs font-medium text-foreground">
+                                {isAI ? "Open Paper" : user?.name || "User"}
+                            </span>
+                            <span className="text-[11px] text-muted-foreground">
+                                {formatAnnotationDate(ann.created_at)}
+                            </span>
+                        </div>
+                        <p className="text-sm text-foreground leading-snug whitespace-pre-wrap break-words line-clamp-4 pl-8">
+                            {ann.content}
+                        </p>
+                    </div>
+                );
+            })}
+        </div>,
+        document.body
+    );
+}

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { User as UserIcon } from 'lucide-react';
+import { File, User as UserIcon } from 'lucide-react';
 
 import {
 	HighlightColor,
@@ -396,11 +396,15 @@ export function AnnotationsView({
 											/>
 										</div>
 									) : null}
-									{visible.map((annotation) => (
+									{visible.map((annotation) => {
+										const isAI = annotation.role === 'assistant';
+										return (
 										<div key={annotation.id} className="flex flex-col gap-2">
 											<div className="flex items-center gap-2">
-												<div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 bg-muted flex items-center justify-center">
-													{user?.picture ? (
+												<div className={`w-8 h-8 rounded-full overflow-hidden flex-shrink-0 flex items-center justify-center ${isAI ? 'bg-blue-100 dark:bg-blue-900' : 'bg-muted'}`}>
+													{isAI ? (
+														<File size={14} className="text-blue-500" />
+													) : user?.picture ? (
 														// eslint-disable-next-line @next/next/no-img-element
 														<img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
 													) : (
@@ -408,7 +412,7 @@ export function AnnotationsView({
 													)}
 												</div>
 												<span className="text-sm font-medium text-foreground">
-													{user?.name || 'User'}
+													{isAI ? 'Open Paper' : user?.name || 'User'}
 												</span>
 												<span className="text-xs text-muted-foreground">
 													{formatAnnotationDate(annotation.created_at)}
@@ -422,7 +426,7 @@ export function AnnotationsView({
 												/>
 											</div>
 										</div>
-									))}
+									)})}
 									{moreCount > 0 && (
 										<p className="text-xs text-muted-foreground pl-10">
 											+{moreCount} more {moreCount === 1 ? 'reply' : 'replies'} — click to show

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { User as UserIcon } from 'lucide-react';
 
 import {
@@ -36,10 +36,9 @@ interface AnnotationsViewProps {
 	renderedHighlightPositions?: Map<string, RenderedHighlightPosition>;
 }
 
-interface FlatAnnotationItem {
+interface AnnotationThread {
 	highlight: PaperHighlight;
-	annotation: PaperHighlightAnnotation;
-	isFirstForHighlight: boolean;
+	annotations: PaperHighlightAnnotation[];
 }
 
 export function AnnotationsView({
@@ -52,17 +51,11 @@ export function AnnotationsView({
 }: AnnotationsViewProps) {
 	const firstAnnotationRefs = useRef<Record<string, HTMLDivElement | null>>({});
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const prevActiveIdRef = useRef<string | null>(null);
+	/** highlight id → expanded full thread (same behavior as inline annotation card) */
+	const [expandedThreads, setExpandedThreads] = useState<Record<string, boolean>>({});
 
-	useEffect(() => {
-		if (activeHighlight?.id) {
-			const element = firstAnnotationRefs.current[activeHighlight.id];
-			if (element && scrollContainerRef.current) {
-				smoothScrollTo(element, scrollContainerRef.current);
-			}
-		}
-	}, [activeHighlight]);
-
-	const flatItems = React.useMemo<FlatAnnotationItem[]>(() => {
+	const threads = useMemo<AnnotationThread[]>(() => {
 		const annotationMap = new Map<string, PaperHighlightAnnotation[]>();
 		for (const ann of annotations) {
 			const existing = annotationMap.get(ann.highlight_id) ?? [];
@@ -105,31 +98,41 @@ export function AnnotationsView({
 			return aTop - bTop;
 		});
 
-		const items: FlatAnnotationItem[] = [];
-		for (const highlight of sorted) {
-			const anns = annotationMap.get(highlight.id!) ?? [];
-			anns.forEach((ann) => {
-				items.push({ highlight, annotation: ann, isFirstForHighlight: false });
-			});
-		}
-
-		// Sort all items newest → oldest
-		items.sort(
-			(a, b) =>
-				new Date(b.annotation.created_at).getTime() -
-				new Date(a.annotation.created_at).getTime()
-		);
-
-		// Recompute isFirstForHighlight after the sort so refs anchor correctly
-		const seenHighlightIds = new Set<string>();
-		return items.map((item) => {
-			const isFirst = !seenHighlightIds.has(item.highlight.id!);
-			seenHighlightIds.add(item.highlight.id!);
-			return { ...item, isFirstForHighlight: isFirst };
-		});
+		return sorted.map((highlight) => ({
+			highlight,
+			annotations: (annotationMap.get(highlight.id!) ?? []).sort(
+				(a, b) =>
+					new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+			),
+		}));
 	}, [highlights, annotations, renderedHighlightPositions]);
 
-	if (flatItems.length === 0) {
+	useEffect(() => {
+		if (activeHighlight?.id) {
+			const element = firstAnnotationRefs.current[activeHighlight.id];
+			if (element && scrollContainerRef.current) {
+				smoothScrollTo(element, scrollContainerRef.current);
+			}
+		}
+	}, [activeHighlight]);
+
+	// When the active highlight changes, collapse only the *previous* highlight's thread — not the
+	// newly selected one. Clearing the whole map was wiping expansion set in the same click as
+	// switching highlights (e.g. B → A required two clicks to expand A).
+	useEffect(() => {
+		const id = activeHighlight?.id ?? null;
+		const prev = prevActiveIdRef.current;
+		if (prev !== null && id !== null && prev !== id) {
+			setExpandedThreads((prevMap) => {
+				const next = { ...prevMap };
+				delete next[prev];
+				return next;
+			});
+		}
+		prevActiveIdRef.current = id;
+	}, [activeHighlight?.id]);
+
+	if (threads.length === 0) {
 		return (
 			<div className="flex flex-col gap-4 text-center">
 				<p className="text-secondary-foreground text-sm">
@@ -143,43 +146,65 @@ export function AnnotationsView({
 		<div className="flex flex-col h-full">
 			<div className="flex-1 overflow-auto" ref={scrollContainerRef}>
 				<div className="divide-y divide-border">
-					{flatItems.map(({ highlight, annotation, isFirstForHighlight }) => {
-						const isActive = activeHighlight?.id === highlight.id;
+					{threads.map(({ highlight, annotations: threadAnns }) => {
+						const hid = highlight.id!;
+						const isActive = activeHighlight?.id === hid;
 						const color: HighlightColor = highlight.role === 'assistant'
 							? 'purple'
 							: (highlight.color || 'blue');
 						const bg = isActive ? ITEM_BG_ACTIVE_MAP[color] : ITEM_BG_MAP[color];
 
+						const hasMulti = threadAnns.length > 1;
+						const expanded = expandedThreads[hid] ?? false;
+						const visible =
+							!hasMulti || expanded ? threadAnns : threadAnns.slice(0, 1);
+						const moreCount = hasMulti && !expanded ? threadAnns.length - 1 : 0;
+
 						return (
 							<div
-								key={annotation.id}
+								key={hid}
+								data-annotation-sidebar-row=""
 								ref={(el) => {
-									if (isFirstForHighlight && highlight.id) {
-										firstAnnotationRefs.current[highlight.id] = el;
-									}
+									firstAnnotationRefs.current[hid] = el;
 								}}
 								className={`px-4 py-3 cursor-pointer transition-colors ${bg}`}
-								onClick={() => onHighlightClick(highlight)}
+								onClick={() => {
+									onHighlightClick(highlight);
+									if (hasMulti && !expanded) {
+										setExpandedThreads((prev) => ({ ...prev, [hid]: true }));
+									}
+								}}
 							>
-								<div className="flex items-center gap-2 mb-2">
-									<div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 bg-muted flex items-center justify-center">
-										{user?.picture ? (
-											// eslint-disable-next-line @next/next/no-img-element
-											<img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
-										) : (
-											<UserIcon size={14} className="text-muted-foreground" />
-										)}
-									</div>
-									<span className="text-sm font-medium text-foreground">
-										{user?.name || 'User'}
-									</span>
-									<span className="text-xs text-muted-foreground">
-										{formatDate(annotation.created_at)}
-									</span>
+								<div className="flex flex-col gap-3">
+									{visible.map((annotation) => (
+										<div key={annotation.id} className="flex flex-col gap-2">
+											<div className="flex items-center gap-2">
+												<div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 bg-muted flex items-center justify-center">
+													{user?.picture ? (
+														// eslint-disable-next-line @next/next/no-img-element
+														<img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
+													) : (
+														<UserIcon size={14} className="text-muted-foreground" />
+													)}
+												</div>
+												<span className="text-sm font-medium text-foreground">
+													{user?.name || 'User'}
+												</span>
+												<span className="text-xs text-muted-foreground">
+													{formatDate(annotation.created_at)}
+												</span>
+											</div>
+											<p className="text-sm text-foreground leading-snug whitespace-pre-wrap pl-10">
+												{annotation.content}
+											</p>
+										</div>
+									))}
+									{moreCount > 0 && (
+										<p className="text-xs text-muted-foreground pl-10">
+											+{moreCount} more {moreCount === 1 ? 'reply' : 'replies'} — click to show
+										</p>
+									)}
 								</div>
-								<p className="text-sm text-foreground leading-snug whitespace-pre-wrap pl-10">
-									{annotation.content}
-								</p>
 							</div>
 						);
 					})}

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -11,6 +11,7 @@ import { smoothScrollTo } from '@/lib/animation';
 import { BasicUser } from "@/lib/auth";
 import { cn, formatAnnotationDate } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
+import { CollapsibleNoteText } from '@/components/CollapsibleNoteText';
 
 const ITEM_BG_MAP: Record<HighlightColor, string> = {
 	yellow: "bg-yellow-50 dark:bg-yellow-950/20",
@@ -297,9 +298,11 @@ export function AnnotationsView({
 									QUOTE_ACCENT_BORDER[highlightSwatchColor(composeTargetHighlight)]
 								)}
 							>
-								<p className="text-xs text-muted-foreground whitespace-pre-wrap break-words">
-									{composeTargetHighlight.raw_text}
-								</p>
+								<CollapsibleNoteText
+									content={composeTargetHighlight.raw_text}
+									isActive={Boolean(composeHighlightId)}
+									paragraphClassName="text-xs text-muted-foreground whitespace-pre-wrap break-words"
+								/>
 							</div>
 						) : null}
 						<textarea
@@ -386,9 +389,11 @@ export function AnnotationsView({
 												QUOTE_ACCENT_BORDER[color]
 											)}
 										>
-											<p className="text-xs text-muted-foreground whitespace-pre-wrap break-words">
-												{highlight.raw_text}
-											</p>
+											<CollapsibleNoteText
+												content={highlight.raw_text}
+												isActive={isActive}
+												paragraphClassName="text-xs text-muted-foreground whitespace-pre-wrap break-words"
+											/>
 										</div>
 									) : null}
 									{visible.map((annotation) => (
@@ -409,9 +414,13 @@ export function AnnotationsView({
 													{formatAnnotationDate(annotation.created_at)}
 												</span>
 											</div>
-											<p className="text-sm text-foreground leading-snug whitespace-pre-wrap pl-10">
-												{annotation.content}
-											</p>
+											<div className="pl-10">
+												<CollapsibleNoteText
+													content={annotation.content}
+													isActive={isActive}
+													paragraphClassName="text-sm text-foreground leading-snug whitespace-pre-wrap break-words"
+												/>
+											</div>
 										</div>
 									))}
 									{moreCount > 0 && (

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { User as UserIcon } from 'lucide-react';
 
 import {
@@ -9,7 +9,8 @@ import {
 import { RenderedHighlightPosition } from './PdfHighlighterViewer';
 import { smoothScrollTo } from '@/lib/animation';
 import { BasicUser } from "@/lib/auth";
-import { formatDate } from '@/lib/utils';
+import { formatAnnotationDate } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
 const ITEM_BG_MAP: Record<HighlightColor, string> = {
 	yellow: "bg-yellow-50 dark:bg-yellow-950/20",
@@ -19,13 +20,15 @@ const ITEM_BG_MAP: Record<HighlightColor, string> = {
 	purple: "bg-purple-50 dark:bg-purple-950/20",
 };
 
-const ITEM_BG_ACTIVE_MAP: Record<HighlightColor, string> = {
-	yellow: "bg-yellow-100 dark:bg-yellow-900/30",
-	green:  "bg-green-100 dark:bg-green-900/30",
-	blue:   "bg-blue-100 dark:bg-blue-900/30",
-	pink:   "bg-pink-100 dark:bg-pink-900/30",
-	purple: "bg-purple-100 dark:bg-purple-900/30",
-};
+/** Matches `InlineAnnotationCard` reply field — max-h-48 */
+const REPLY_TEXTAREA_MAX_PX = 192;
+function autoResizeReplyTextarea(el: HTMLTextAreaElement) {
+	el.style.height = "auto";
+	el.style.height = `${Math.min(el.scrollHeight, REPLY_TEXTAREA_MAX_PX)}px`;
+}
+
+const inlineReplyTextareaClassName =
+	"text-sm text-foreground placeholder:text-muted-foreground resize-none w-full min-h-[4rem] max-h-48 px-3 py-2 overflow-y-auto overflow-x-hidden box-border rounded-md border border-black bg-background focus:outline-none focus:ring-0 focus:border-black dark:border-white dark:focus:border-white";
 
 interface AnnotationsViewProps {
 	highlights: PaperHighlight[];
@@ -34,6 +37,10 @@ interface AnnotationsViewProps {
 	activeHighlight?: PaperHighlight | null;
 	user: BasicUser;
 	renderedHighlightPositions?: Map<string, RenderedHighlightPosition>;
+	composeHighlightId?: string | null;
+	onComposeHighlightDismiss?: () => void;
+	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
+	readonly?: boolean;
 }
 
 interface AnnotationThread {
@@ -48,12 +55,24 @@ export function AnnotationsView({
 	activeHighlight,
 	user,
 	renderedHighlightPositions,
+	composeHighlightId = null,
+	onComposeHighlightDismiss,
+	addAnnotation,
+	readonly = false,
 }: AnnotationsViewProps) {
 	const firstAnnotationRefs = useRef<Record<string, HTMLDivElement | null>>({});
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
+	const composeBlockRef = useRef<HTMLDivElement | null>(null);
+	const composeTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 	const prevActiveIdRef = useRef<string | null>(null);
 	/** highlight id → expanded full thread (same behavior as inline annotation card) */
 	const [expandedThreads, setExpandedThreads] = useState<Record<string, boolean>>({});
+	const [composeDraft, setComposeDraft] = useState('');
+	const [isComposeSaving, setIsComposeSaving] = useState(false);
+	const [replyOpen, setReplyOpen] = useState(false);
+	const [replyDraft, setReplyDraft] = useState('');
+	const [isReplySaving, setIsReplySaving] = useState(false);
+	const replyTextareaRef = useRef<HTMLTextAreaElement | null>(null);
 
 	const threads = useMemo<AnnotationThread[]>(() => {
 		const annotationMap = new Map<string, PaperHighlightAnnotation[]>();
@@ -64,38 +83,33 @@ export function AnnotationsView({
 		}
 
 		const annotatedHighlights = highlights.filter((h) => {
-			if (!h.id || !annotationMap.has(h.id)) return false;
+			if (!h.id) return false;
+			if (composeHighlightId && h.id === composeHighlightId) return true;
+			if (!annotationMap.has(h.id)) return false;
 			if (h.role === 'user') return true;
 			if (h.position) return true;
 			if (h.id && renderedHighlightPositions?.has(h.id)) return true;
 			return false;
 		});
 
+		const latestMsForHighlight = (highlightId: string): number => {
+			const anns = annotationMap.get(highlightId) ?? [];
+			if (anns.length === 0) {
+				if (composeHighlightId === highlightId) return Number.MAX_SAFE_INTEGER;
+				return 0;
+			}
+			return Math.max(
+				...anns.map((ann) => new Date(ann.created_at).getTime())
+			);
+		};
+
 		const sorted = [...annotatedHighlights].sort((a, b) => {
-			let aPage = a.page_number || 0;
-			let aTop = 0;
-			if (a.position) {
-				aPage = a.position.boundingRect.pageNumber || aPage;
-				aTop = a.position.boundingRect.y1;
-			} else if (a.id && renderedHighlightPositions?.has(a.id)) {
-				const pos = renderedHighlightPositions.get(a.id)!;
-				aPage = pos.page;
-				aTop = pos.top;
-			}
-
-			let bPage = b.page_number || 0;
-			let bTop = 0;
-			if (b.position) {
-				bPage = b.position.boundingRect.pageNumber || bPage;
-				bTop = b.position.boundingRect.y1;
-			} else if (b.id && renderedHighlightPositions?.has(b.id)) {
-				const pos = renderedHighlightPositions.get(b.id)!;
-				bPage = pos.page;
-				bTop = pos.top;
-			}
-
-			if (aPage !== bPage) return aPage - bPage;
-			return aTop - bTop;
+			const idA = a.id!;
+			const idB = b.id!;
+			const tA = latestMsForHighlight(idA);
+			const tB = latestMsForHighlight(idB);
+			if (tB !== tA) return tB - tA;
+			return idA.localeCompare(idB);
 		});
 
 		return sorted.map((highlight) => ({
@@ -105,7 +119,18 @@ export function AnnotationsView({
 					new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
 			),
 		}));
-	}, [highlights, annotations, renderedHighlightPositions]);
+	}, [highlights, annotations, renderedHighlightPositions, composeHighlightId]);
+
+	const listThreads = useMemo(() => {
+		if (!composeHighlightId) return threads;
+		return threads.filter(
+			(t) =>
+				!(
+					t.highlight.id === composeHighlightId &&
+					t.annotations.length === 0
+				)
+		);
+	}, [threads, composeHighlightId]);
 
 	useEffect(() => {
 		if (activeHighlight?.id) {
@@ -132,7 +157,77 @@ export function AnnotationsView({
 		prevActiveIdRef.current = id;
 	}, [activeHighlight?.id]);
 
-	if (threads.length === 0) {
+	useEffect(() => {
+		setComposeDraft('');
+	}, [composeHighlightId]);
+
+	useEffect(() => {
+		setReplyOpen(false);
+		setReplyDraft('');
+	}, [activeHighlight?.id]);
+
+	useLayoutEffect(() => {
+		if (!replyOpen) return;
+		const el = replyTextareaRef.current;
+		if (!el) return;
+		el.focus();
+		autoResizeReplyTextarea(el);
+	}, [replyOpen]);
+
+	useLayoutEffect(() => {
+		if (!composeHighlightId) return;
+		const el = composeTextareaRef.current;
+		if (!el) return;
+		el.focus();
+		autoResizeReplyTextarea(el);
+	}, [composeHighlightId]);
+
+	useEffect(() => {
+		if (!composeHighlightId || !composeBlockRef.current || !scrollContainerRef.current) return;
+		smoothScrollTo(composeBlockRef.current, scrollContainerRef.current);
+	}, [composeHighlightId]);
+
+	const composeTargetHighlight = composeHighlightId
+		? highlights.find((h) => h.id === composeHighlightId)
+		: undefined;
+
+	const handleComposeSave = async () => {
+		if (
+			!composeHighlightId ||
+			!addAnnotation ||
+			!composeDraft.trim() ||
+			isComposeSaving
+		)
+			return;
+		setIsComposeSaving(true);
+		try {
+			await addAnnotation(composeHighlightId, composeDraft.trim());
+			setComposeDraft('');
+			onComposeHighlightDismiss?.();
+		} finally {
+			setIsComposeSaving(false);
+		}
+	};
+
+	const handleComposeCancel = () => {
+		setComposeDraft('');
+		onComposeHighlightDismiss?.();
+	};
+
+	const handleReplySave = async (highlightId: string) => {
+		if (!addAnnotation || !replyDraft.trim() || isReplySaving) return;
+		setIsReplySaving(true);
+		try {
+			await addAnnotation(highlightId, replyDraft.trim());
+			setReplyDraft('');
+			setReplyOpen(false);
+			setExpandedThreads((prev) => ({ ...prev, [highlightId]: true }));
+		} finally {
+			setIsReplySaving(false);
+		}
+	};
+
+	if (threads.length === 0 && !composeHighlightId) {
 		return (
 			<div className="flex flex-col gap-4 text-center">
 				<p className="text-secondary-foreground text-sm">
@@ -145,14 +240,75 @@ export function AnnotationsView({
 	return (
 		<div className="flex flex-col h-full">
 			<div className="flex-1 overflow-auto" ref={scrollContainerRef}>
+				{composeHighlightId && addAnnotation && !readonly && (
+					<div
+						ref={composeBlockRef}
+						className="sticky top-0 z-10 border-b border-border bg-background px-4 py-3 shadow-sm"
+					>
+						<p className="text-xs font-medium text-muted-foreground mb-2">
+							New note
+						</p>
+						{composeTargetHighlight?.raw_text ? (
+							<p className="text-xs text-muted-foreground line-clamp-3 mb-2 whitespace-pre-wrap">
+								<span className="text-muted-foreground/80">&quot;</span>
+								{composeTargetHighlight.raw_text}
+								<span className="text-muted-foreground/80">&quot;</span>
+							</p>
+						) : null}
+						<textarea
+							ref={composeTextareaRef}
+							value={composeDraft}
+							onChange={(e) => {
+								setComposeDraft(e.target.value);
+								autoResizeReplyTextarea(e.target);
+							}}
+							onKeyDown={(e) => {
+								if (e.key === 'Enter' && !e.shiftKey) {
+									e.preventDefault();
+									void handleComposeSave();
+								} else if (e.key === 'Escape') {
+									handleComposeCancel();
+								}
+							}}
+							placeholder="Write a note…"
+							aria-label="New note"
+							className={inlineReplyTextareaClassName}
+							disabled={isComposeSaving}
+							rows={3}
+						/>
+						<div className="flex items-center justify-end gap-2 mt-2">
+							<Button
+								type="button"
+								variant="ghost"
+								size="sm"
+								className="h-7 px-2 text-xs text-muted-foreground"
+								onClick={handleComposeCancel}
+								disabled={isComposeSaving}
+							>
+								Cancel
+							</Button>
+							<Button
+								type="button"
+								size="sm"
+								className="h-7 px-3 text-xs"
+								onClick={() => void handleComposeSave()}
+								disabled={isComposeSaving || !composeDraft.trim()}
+							>
+								Save
+							</Button>
+						</div>
+					</div>
+				)}
 				<div className="divide-y divide-border">
-					{threads.map(({ highlight, annotations: threadAnns }) => {
+					{listThreads.map(({ highlight, annotations: threadAnns }) => {
 						const hid = highlight.id!;
 						const isActive = activeHighlight?.id === hid;
 						const color: HighlightColor = highlight.role === 'assistant'
 							? 'purple'
 							: (highlight.color || 'blue');
-						const bg = isActive ? ITEM_BG_ACTIVE_MAP[color] : ITEM_BG_MAP[color];
+						const bg = isActive
+							? "bg-white dark:bg-zinc-950"
+							: ITEM_BG_MAP[color];
 
 						const hasMulti = threadAnns.length > 1;
 						const expanded = expandedThreads[hid] ?? false;
@@ -191,7 +347,7 @@ export function AnnotationsView({
 													{user?.name || 'User'}
 												</span>
 												<span className="text-xs text-muted-foreground">
-													{formatDate(annotation.created_at)}
+													{formatAnnotationDate(annotation.created_at)}
 												</span>
 											</div>
 											<p className="text-sm text-foreground leading-snug whitespace-pre-wrap pl-10">
@@ -205,6 +361,83 @@ export function AnnotationsView({
 										</p>
 									)}
 								</div>
+								{isActive && addAnnotation && !readonly && (
+									<div
+										className="mt-2 pt-0"
+										onMouseDown={(e) => e.stopPropagation()}
+										onClick={(e) => e.stopPropagation()}
+									>
+										{replyOpen ? (
+											<div className="flex flex-col gap-2">
+												<textarea
+													ref={replyTextareaRef}
+													value={replyDraft}
+													onChange={(e) => {
+														setReplyDraft(e.target.value);
+														autoResizeReplyTextarea(e.target);
+													}}
+													onKeyDown={(e) => {
+														if (e.key === 'Enter' && !e.shiftKey) {
+															e.preventDefault();
+															void handleReplySave(hid);
+														} else if (e.key === 'Escape') {
+															setReplyOpen(false);
+															setReplyDraft('');
+														}
+													}}
+													onMouseDown={(e) => e.stopPropagation()}
+													placeholder="Write a reply…"
+													aria-label="Reply"
+													className={inlineReplyTextareaClassName}
+													disabled={isReplySaving}
+													rows={3}
+												/>
+												<div className="flex items-center justify-end gap-2">
+													<Button
+														type="button"
+														variant="ghost"
+														size="sm"
+														className="h-7 px-2 text-xs text-muted-foreground"
+														disabled={isReplySaving}
+														onClick={(e) => {
+															e.stopPropagation();
+															setReplyOpen(false);
+															setReplyDraft('');
+														}}
+														onMouseDown={(e) => e.stopPropagation()}
+													>
+														Cancel
+													</Button>
+													<Button
+														type="button"
+														size="sm"
+														className="h-7 px-3 text-xs"
+														disabled={isReplySaving || !replyDraft.trim()}
+														onClick={(e) => {
+															e.stopPropagation();
+															void handleReplySave(hid);
+														}}
+														onMouseDown={(e) => e.stopPropagation()}
+													>
+														Reply
+													</Button>
+												</div>
+											</div>
+										) : (
+											<button
+												type="button"
+												className="w-full text-left text-sm text-muted-foreground rounded-full border border-border px-3 py-1.5 hover:bg-muted/50 transition-colors cursor-text"
+												onMouseDown={(e) => e.stopPropagation()}
+												onClick={(e) => {
+													e.stopPropagation();
+													setReplyOpen(true);
+												}}
+											>
+												Reply…
+											</button>
+										)}
+									</div>
+								)}
 							</div>
 						);
 					})}

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -1,4 +1,5 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
+import { User as UserIcon } from 'lucide-react';
 
 import {
 	HighlightColor,
@@ -6,276 +7,78 @@ import {
 	PaperHighlightAnnotation,
 } from '@/lib/schema';
 import { RenderedHighlightPosition } from './PdfHighlighterViewer';
-
-import { Button } from '@/components/ui/button';
-import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
 import { smoothScrollTo } from '@/lib/animation';
 import { BasicUser } from "@/lib/auth";
-import { User as UserIcon } from 'lucide-react';
-import Annotation from './Annotation';
+import { formatDate } from '@/lib/utils';
 
-// Map highlight color names to bg color classes for the left bar
-const HIGHLIGHT_BAR_COLOR_MAP: Record<HighlightColor, string> = {
-	yellow: "bg-yellow-400",
-	green: "bg-green-500",
-	blue: "bg-blue-400",
-	pink: "bg-pink-400",
-	purple: "bg-purple-400",
+const ITEM_BG_MAP: Record<HighlightColor, string> = {
+	yellow: "bg-yellow-50 dark:bg-yellow-950/20",
+	green:  "bg-green-50 dark:bg-green-950/20",
+	blue:   "bg-blue-50 dark:bg-blue-950/20",
+	pink:   "bg-pink-50 dark:bg-pink-950/20",
+	purple: "bg-purple-50 dark:bg-purple-950/20",
 };
 
-export interface AnnotationButtonProps {
-	highlightId: string;
-	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
-	user?: BasicUser;
-}
-
-export function AnnotationButton({ highlightId, addAnnotation, user }: AnnotationButtonProps) {
-	const [content, setContent] = useState("");
-	const [isTyping, setIsTyping] = useState(false);
-	const [isAdding, setIsAdding] = useState(false);
-
-	const now = new Date();
-	const timeStr = now.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-
-	const handleSave = async () => {
-		if (content.trim() && addAnnotation) {
-			setIsAdding(true);
-			await addAnnotation(highlightId, content);
-			setContent("");
-			setIsTyping(false);
-			setIsAdding(false);
-		}
-	};
-
-	const handleCancel = () => {
-		setContent("");
-		setIsTyping(false);
-	};
-
-	if (!addAnnotation) return null;
-
-	return (
-		<div className="mt-1">
-			{/* Avatar row */}
-			<div className="flex items-center gap-2 mb-2">
-				<div className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden bg-muted">
-					{user?.picture ? (
-						// eslint-disable-next-line @next/next/no-img-element
-						<img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
-					) : (
-						<UserIcon size={14} className="text-muted-foreground" />
-					)}
-				</div>
-				<span className="text-sm font-medium text-foreground">{user?.name || 'User'}</span>
-				<span className="text-xs text-muted-foreground">{timeStr}</span>
-			</div>
-
-			<Textarea
-				value={content}
-				onChange={(e) => {
-					setContent(e.target.value);
-					if (!isTyping) setIsTyping(true);
-				}}
-				onKeyDown={(e => {
-					if (e.key === 'Enter' && !e.shiftKey) {
-						e.preventDefault();
-						handleSave();
-					}
-				})}
-				placeholder="Store your thoughts here."
-				className="ml-10 w-[calc(100%-2.5rem)] text-sm focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-foreground focus-visible:border-foreground"
-				rows={3}
-				autoFocus
-			/>
-			{isTyping && (
-				<div className="flex justify-end gap-2 mt-2">
-					<Button variant="outline" size="sm" onClick={handleCancel} disabled={isAdding}>
-						Cancel
-					</Button>
-					<Button size="sm" onClick={handleSave} disabled={isAdding || !content.trim()}>
-						Save
-					</Button>
-				</div>
-			)}
-		</div>
-	);
-}
-
-interface HighlightThreadProps {
-	highlight: PaperHighlight;
-	annotations: PaperHighlightAnnotation[];
-	isActive: boolean;
-	onClick: () => void;
-	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
-	removeAnnotation?: (annotationId: string) => void;
-	updateAnnotation?: (annotationId: string, content: string) => void;
-	user?: BasicUser
-	readonly?: boolean;
-}
-
-
-// HighlightThread Component
-function HighlightThread({
-	highlight,
-	annotations,
-	isActive,
-	onClick,
-	addAnnotation,
-	removeAnnotation,
-	updateAnnotation,
-	user,
-	readonly,
-}: HighlightThreadProps) {
-
-	const barColor = highlight.role === 'assistant'
-		? 'bg-purple-400'
-		: HIGHLIGHT_BAR_COLOR_MAP[highlight.color || 'blue'];
-
-	return (
-		<div
-			className={`cursor-pointer rounded-lg px-3 py-3 transition-colors ${isActive ? 'bg-secondary' : 'hover:bg-secondary/50'}`}
-			onClick={onClick}
-		>
-			{/* Quoted highlight text with colored left bar */}
-			<div className="flex gap-2.5">
-				<div className={`w-0.5 rounded-full shrink-0 self-stretch ${barColor}`} />
-				<div className="min-w-0">
-					{highlight.type && (
-						<span className="text-[10px] text-purple-600 dark:text-purple-400 font-medium block mb-0.5">
-							{highlight.type.replace('_', ' ').toLowerCase()}
-						</span>
-					)}
-					<p className="text-foreground text-sm leading-snug">
-						{highlight.raw_text}
-					</p>
-				</div>
-			</div>
-
-			{/* Annotation notes */}
-			{annotations.length > 0 && (
-				<div className="space-y-3 mt-3">
-					{annotations.map((annotation) => (
-						<Annotation
-							key={annotation.id}
-							annotation={{ ...annotation }}
-							highlightColor={highlight.role === 'assistant' ? 'purple' : (highlight.color || 'blue')}
-							removeAnnotation={removeAnnotation}
-							updateAnnotation={updateAnnotation}
-							user={user}
-							readonly={readonly}
-						/>
-					))}
-				</div>
-			)}
-
-			{isActive && !readonly && addAnnotation && highlight.id && (
-				<div className="mt-3">
-					<AnnotationButton
-						highlightId={highlight.id}
-						addAnnotation={addAnnotation}
-						user={user}
-					/>
-				</div>
-			)}
-		</div>
-	);
-}
+const ITEM_BG_ACTIVE_MAP: Record<HighlightColor, string> = {
+	yellow: "bg-yellow-100 dark:bg-yellow-900/30",
+	green:  "bg-green-100 dark:bg-green-900/30",
+	blue:   "bg-blue-100 dark:bg-blue-900/30",
+	pink:   "bg-pink-100 dark:bg-pink-900/30",
+	purple: "bg-purple-100 dark:bg-purple-900/30",
+};
 
 interface AnnotationsViewProps {
 	highlights: PaperHighlight[];
 	annotations: PaperHighlightAnnotation[];
 	onHighlightClick: (highlight: PaperHighlight) => void;
 	activeHighlight?: PaperHighlight | null;
-	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
-	removeAnnotation?: (annotationId: string) => void;
-	updateAnnotation?: (annotationId: string, content: string) => void;
 	user: BasicUser;
-	readonly?: boolean;
 	renderedHighlightPositions?: Map<string, RenderedHighlightPosition>;
 }
 
-interface AnnotationsToolbarProps {
-	onShowJustMine: (show: boolean) => void;
-	showJustMine: boolean;
-	readonly: boolean;
+interface FlatAnnotationItem {
+	highlight: PaperHighlight;
+	annotation: PaperHighlightAnnotation;
+	isFirstForHighlight: boolean;
 }
 
-function AnnotationsToolbar({
-	onShowJustMine,
-	showJustMine,
-	readonly,
-}: AnnotationsToolbarProps) {
-	return (
-		<div className="flex items-center gap-3 px-3 py-2 border-b border-border bg-muted/20">
-			{
-				!readonly && (
-					<div className="flex items-center gap-2">
-						<Switch
-							checked={showJustMine}
-							onCheckedChange={onShowJustMine}
-							id="just-mine"
-						/>
-						<label htmlFor="just-mine" className="text-sm font-medium text-foreground cursor-pointer flex items-center gap-1">
-							<UserIcon size={14} />
-							Just mine
-						</label>
-					</div>
-				)
-			}
-		</div>
-	);
-}
-
-export function AnnotationsView(
-	{
-		highlights,
-		annotations,
-		onHighlightClick,
-		addAnnotation,
-		activeHighlight,
-		removeAnnotation,
-		updateAnnotation,
-		user,
-		readonly = false,
-		renderedHighlightPositions,
-	}: AnnotationsViewProps
-) {
-	// All your existing useEffect hooks for sorting and mapping data remain the same
-	const [sortedHighlights, setSortedHighlights] = React.useState<PaperHighlight[]>([]);
-	const [filteredHighlights, setFilteredHighlights] = React.useState<PaperHighlight[]>([]);
-	const [highlightAnnotationMap, setHighlightAnnotationMap] = React.useState<Map<string, PaperHighlightAnnotation[]>>(new Map());
-	const [showJustMine, setShowJustMine] = React.useState<boolean>(false);
-	const highlightRefs = useRef<Record<string, HTMLDivElement | null>>({});
+export function AnnotationsView({
+	highlights,
+	annotations,
+	onHighlightClick,
+	activeHighlight,
+	user,
+	renderedHighlightPositions,
+}: AnnotationsViewProps) {
+	const firstAnnotationRefs = useRef<Record<string, HTMLDivElement | null>>({});
 	const scrollContainerRef = useRef<HTMLDivElement | null>(null);
 
 	useEffect(() => {
 		if (activeHighlight?.id) {
-			const element = highlightRefs.current[activeHighlight.id];
+			const element = firstAnnotationRefs.current[activeHighlight.id];
 			if (element && scrollContainerRef.current) {
 				smoothScrollTo(element, scrollContainerRef.current);
 			}
 		}
 	}, [activeHighlight]);
 
-	useEffect(() => {
-		// Filter out assistant highlights that don't have a rendered position
-		// (they couldn't be found in the PDF text)
-		const visibleHighlights = highlights.filter((h) => {
-			// User highlights are always shown
+	const flatItems = React.useMemo<FlatAnnotationItem[]>(() => {
+		const annotationMap = new Map<string, PaperHighlightAnnotation[]>();
+		for (const ann of annotations) {
+			const existing = annotationMap.get(ann.highlight_id) ?? [];
+			existing.push(ann);
+			annotationMap.set(ann.highlight_id, existing);
+		}
+
+		const annotatedHighlights = highlights.filter((h) => {
+			if (!h.id || !annotationMap.has(h.id)) return false;
 			if (h.role === 'user') return true;
-			// Highlights with stored position data are shown
 			if (h.position) return true;
-			// Assistant highlights need a rendered position to be shown
 			if (h.id && renderedHighlightPositions?.has(h.id)) return true;
 			return false;
 		});
 
-		// Sort highlights by position
-		// For highlights with position data (user highlights), use boundingRect
-		// For assistant highlights without position, use renderedHighlightPositions from DOM
-		const sortedHighlights = [...visibleHighlights].sort((a, b) => {
-			// Get position for highlight a
+		const sorted = [...annotatedHighlights].sort((a, b) => {
 			let aPage = a.page_number || 0;
 			let aTop = 0;
 			if (a.position) {
@@ -287,7 +90,6 @@ export function AnnotationsView(
 				aTop = pos.top;
 			}
 
-			// Get position for highlight b
 			let bPage = b.page_number || 0;
 			let bTop = 0;
 			if (b.position) {
@@ -299,53 +101,39 @@ export function AnnotationsView(
 				bTop = pos.top;
 			}
 
-			// Sort by page first, then by vertical position
-			if (aPage !== bPage) {
-				return aPage - bPage;
-			}
+			if (aPage !== bPage) return aPage - bPage;
 			return aTop - bTop;
 		});
 
-		setSortedHighlights(sortedHighlights);
-
-		// Handle user annotations
-		const annotationMap = new Map<string, PaperHighlightAnnotation[]>();
-		annotations.forEach((annotation) => {
-			const highlightId = annotation.highlight_id;
-			const existingAnnotations = annotationMap.get(highlightId) || [];
-			existingAnnotations.push(annotation);
-			annotationMap.set(highlightId, existingAnnotations);
-		});
-		setHighlightAnnotationMap(annotationMap);
-	}, [highlights, annotations, renderedHighlightPositions]);
-
-	// Filter highlights based on selected filters
-	useEffect(() => {
-		let filtered = sortedHighlights;
-
-		// Filter to show only user's annotations if enabled
-		if (showJustMine) {
-			filtered = filtered.filter(h => {
-				const highlightAnnotations = h.id ? highlightAnnotationMap.get(h.id) || [] : [];
-				const hasUserAnnotations = highlightAnnotations.some(a => a.role === 'user');
-				const isUserHighlight = h.role === 'user';
-				return isUserHighlight || hasUserAnnotations;
+		const items: FlatAnnotationItem[] = [];
+		for (const highlight of sorted) {
+			const anns = annotationMap.get(highlight.id!) ?? [];
+			anns.forEach((ann) => {
+				items.push({ highlight, annotation: ann, isFirstForHighlight: false });
 			});
 		}
 
-		setFilteredHighlights(filtered);
-	}, [sortedHighlights, showJustMine, highlightAnnotationMap]);
+		// Sort all items newest → oldest
+		items.sort(
+			(a, b) =>
+				new Date(b.annotation.created_at).getTime() -
+				new Date(a.annotation.created_at).getTime()
+		);
 
-	const handleShowJustMine = (show: boolean) => {
-		setShowJustMine(show);
-	};
+		// Recompute isFirstForHighlight after the sort so refs anchor correctly
+		const seenHighlightIds = new Set<string>();
+		return items.map((item) => {
+			const isFirst = !seenHighlightIds.has(item.highlight.id!);
+			seenHighlightIds.add(item.highlight.id!);
+			return { ...item, isFirstForHighlight: isFirst };
+		});
+	}, [highlights, annotations, renderedHighlightPositions]);
 
-
-	if (sortedHighlights.length === 0) {
+	if (flatItems.length === 0) {
 		return (
 			<div className="flex flex-col gap-4 text-center">
 				<p className="text-secondary-foreground text-sm">
-					{readonly ? "There are no annotations for this paper." : "Highlight text in the document to begin annotating."}
+					There are no annotations for this paper.
 				</p>
 			</div>
 		);
@@ -353,52 +141,48 @@ export function AnnotationsView(
 
 	return (
 		<div className="flex flex-col h-full">
-			<AnnotationsToolbar
-				onShowJustMine={handleShowJustMine}
-				showJustMine={showJustMine}
-				readonly={readonly}
-			/>
-
 			<div className="flex-1 overflow-auto" ref={scrollContainerRef}>
-				<div className="space-y-1 p-2">
-					{filteredHighlights.length === 0 ? (
-						<div className="text-center text-muted-foreground text-sm py-8">
-							No highlights match the current filters.
-						</div>
-					) : (
-						filteredHighlights.map((highlight) => {
-							const annotations = (highlight.id && highlightAnnotationMap.get(highlight.id) || [])
-								.filter(annotation => !showJustMine || annotation.role === 'user')
-								.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime());
+				<div className="divide-y divide-border">
+					{flatItems.map(({ highlight, annotation, isFirstForHighlight }) => {
+						const isActive = activeHighlight?.id === highlight.id;
+						const color: HighlightColor = highlight.role === 'assistant'
+							? 'purple'
+							: (highlight.color || 'blue');
+						const bg = isActive ? ITEM_BG_ACTIVE_MAP[color] : ITEM_BG_MAP[color];
 
-							const handleClick = () => {
-								onHighlightClick(highlight);
-							};
-
-							return (
-								<div
-									key={`${highlight.role}-${highlight.id}`}
-									ref={(el) => {
-										if (highlight.id) {
-											highlightRefs.current[highlight.id] = el;
-										}
-									}}
-								>
-									<HighlightThread
-										highlight={highlight}
-										annotations={annotations}
-										isActive={activeHighlight?.id === highlight.id}
-										onClick={handleClick}
-										addAnnotation={addAnnotation}
-										removeAnnotation={removeAnnotation}
-										updateAnnotation={updateAnnotation}
-										user={user ?? undefined}
-										readonly={readonly}
-									/>
+						return (
+							<div
+								key={annotation.id}
+								ref={(el) => {
+									if (isFirstForHighlight && highlight.id) {
+										firstAnnotationRefs.current[highlight.id] = el;
+									}
+								}}
+								className={`px-4 py-3 cursor-pointer transition-colors ${bg}`}
+								onClick={() => onHighlightClick(highlight)}
+							>
+								<div className="flex items-center gap-2 mb-2">
+									<div className="w-8 h-8 rounded-full overflow-hidden flex-shrink-0 bg-muted flex items-center justify-center">
+										{user?.picture ? (
+											// eslint-disable-next-line @next/next/no-img-element
+											<img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
+										) : (
+											<UserIcon size={14} className="text-muted-foreground" />
+										)}
+									</div>
+									<span className="text-sm font-medium text-foreground">
+										{user?.name || 'User'}
+									</span>
+									<span className="text-xs text-muted-foreground">
+										{formatDate(annotation.created_at)}
+									</span>
 								</div>
-							);
-						})
-					)}
+								<p className="text-sm text-foreground leading-snug whitespace-pre-wrap pl-10">
+									{annotation.content}
+								</p>
+							</div>
+						);
+					})}
 				</div>
 			</div>
 		</div>

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -1,28 +1,19 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
+	HighlightColor,
 	PaperHighlight,
 	PaperHighlightAnnotation,
-	HighlightColor,
 } from '@/lib/schema';
 import { RenderedHighlightPosition } from './PdfHighlighterViewer';
 
 import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import { smoothScrollTo } from '@/lib/animation';
 import { BasicUser } from "@/lib/auth";
 import { User as UserIcon } from 'lucide-react';
-import { smoothScrollTo } from '@/lib/animation';
 import Annotation from './Annotation';
-
-// Map highlight color names to Tailwind border classes
-const HIGHLIGHT_BORDER_COLOR_MAP: Record<HighlightColor, string> = {
-	yellow: "border-yellow-400",
-	green: "border-green-500",
-	blue: "border-blue-400",
-	pink: "border-pink-400",
-	purple: "border-purple-400",
-};
 
 // Map highlight color names to bg color classes for the left bar
 const HIGHLIGHT_BAR_COLOR_MAP: Record<HighlightColor, string> = {
@@ -32,16 +23,6 @@ const HIGHLIGHT_BAR_COLOR_MAP: Record<HighlightColor, string> = {
 	pink: "bg-pink-400",
 	purple: "bg-purple-400",
 };
-
-// Map highlight color names to bubble background + border classes for annotation notes
-const BUBBLE_BG_MAP: Record<HighlightColor, string> = {
-	yellow: "bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-800",
-	green:  "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-800",
-	blue:   "bg-blue-50 border-blue-200 dark:bg-blue-950/30 dark:border-blue-800",
-	pink:   "bg-pink-50 border-pink-200 dark:bg-pink-950/30 dark:border-pink-800",
-	purple: "bg-purple-50 border-purple-200 dark:bg-purple-950/30 dark:border-purple-800",
-};
-
 
 export interface AnnotationButtonProps {
 	highlightId: string;

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -293,11 +293,11 @@ export function AnnotationsView({
 						{composeTargetHighlight?.raw_text ? (
 							<div
 								className={cn(
-									"border-l-2 pl-3 mb-2",
+									"min-w-0 border-l-2 pl-3 mb-2",
 									QUOTE_ACCENT_BORDER[highlightSwatchColor(composeTargetHighlight)]
 								)}
 							>
-								<p className="text-xs text-muted-foreground line-clamp-3 whitespace-pre-wrap">
+								<p className="text-xs text-muted-foreground whitespace-pre-wrap break-words">
 									{composeTargetHighlight.raw_text}
 								</p>
 							</div>
@@ -382,11 +382,11 @@ export function AnnotationsView({
 									{highlight.raw_text?.trim() ? (
 										<div
 											className={cn(
-												"border-l-2 pl-3 mb-0",
+												"min-w-0 border-l-2 pl-3 mb-0",
 												QUOTE_ACCENT_BORDER[color]
 											)}
 										>
-											<p className="text-xs text-muted-foreground line-clamp-3 whitespace-pre-wrap">
+											<p className="text-xs text-muted-foreground whitespace-pre-wrap break-words">
 												{highlight.raw_text}
 											</p>
 										</div>

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -30,6 +30,30 @@ function autoResizeReplyTextarea(el: HTMLTextAreaElement) {
 const inlineReplyTextareaClassName =
 	"text-sm text-foreground placeholder:text-muted-foreground resize-none w-full min-h-[4rem] max-h-48 px-3 py-2 overflow-y-auto overflow-x-hidden box-border rounded-md border border-black bg-background focus:outline-none focus:ring-0 focus:border-black dark:border-white dark:focus:border-white";
 
+function annotationCreatedMs(iso: string | undefined): number {
+	if (!iso) return NaN;
+	const t = Date.parse(iso);
+	return Number.isFinite(t) ? t : NaN;
+}
+
+/** Newest annotation in the thread (ms since epoch); used for ordering threads latest → oldest */
+function threadLastActivityMs(
+	annotationMap: Map<string, PaperHighlightAnnotation[]>,
+	highlightId: string,
+	composeHighlightId: string | null
+): number {
+	const anns = annotationMap.get(highlightId);
+	if (!anns?.length) {
+		return composeHighlightId === highlightId ? Number.MAX_SAFE_INTEGER : 0;
+	}
+	let max = 0;
+	for (const ann of anns) {
+		const t = annotationCreatedMs(ann.created_at);
+		if (Number.isFinite(t)) max = Math.max(max, t);
+	}
+	return max;
+}
+
 interface AnnotationsViewProps {
 	highlights: PaperHighlight[];
 	annotations: PaperHighlightAnnotation[];
@@ -38,7 +62,7 @@ interface AnnotationsViewProps {
 	user: BasicUser;
 	renderedHighlightPositions?: Map<string, RenderedHighlightPosition>;
 	composeHighlightId?: string | null;
-	onComposeHighlightDismiss?: () => void;
+	onComposeHighlightDismiss?: (cancelledHighlightId?: string | null) => void;
 	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
 	readonly?: boolean;
 }
@@ -92,32 +116,31 @@ export function AnnotationsView({
 			return false;
 		});
 
-		const latestMsForHighlight = (highlightId: string): number => {
-			const anns = annotationMap.get(highlightId) ?? [];
-			if (anns.length === 0) {
-				if (composeHighlightId === highlightId) return Number.MAX_SAFE_INTEGER;
-				return 0;
-			}
-			return Math.max(
-				...anns.map((ann) => new Date(ann.created_at).getTime())
-			);
-		};
+		const seenIds = new Set<string>();
+		const dedupedHighlights = annotatedHighlights.filter((h) => {
+			if (!h.id || seenIds.has(h.id)) return false;
+			seenIds.add(h.id);
+			return true;
+		});
 
-		const sorted = [...annotatedHighlights].sort((a, b) => {
+		const sorted = [...dedupedHighlights].sort((a, b) => {
 			const idA = a.id!;
 			const idB = b.id!;
-			const tA = latestMsForHighlight(idA);
-			const tB = latestMsForHighlight(idB);
+			const tA = threadLastActivityMs(annotationMap, idA, composeHighlightId);
+			const tB = threadLastActivityMs(annotationMap, idB, composeHighlightId);
 			if (tB !== tA) return tB - tA;
-			return idA.localeCompare(idB);
+			return idB.localeCompare(idA);
 		});
 
 		return sorted.map((highlight) => ({
 			highlight,
-			annotations: (annotationMap.get(highlight.id!) ?? []).sort(
-				(a, b) =>
-					new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
-			),
+			annotations: (annotationMap.get(highlight.id!) ?? []).sort((a, b) => {
+				const ta = annotationCreatedMs(a.created_at);
+				const tb = annotationCreatedMs(b.created_at);
+				return (
+					(Number.isFinite(ta) ? ta : 0) - (Number.isFinite(tb) ? tb : 0)
+				);
+			}),
 		}));
 	}, [highlights, annotations, renderedHighlightPositions, composeHighlightId]);
 
@@ -211,7 +234,7 @@ export function AnnotationsView({
 
 	const handleComposeCancel = () => {
 		setComposeDraft('');
-		onComposeHighlightDismiss?.();
+		onComposeHighlightDismiss?.(composeHighlightId);
 	};
 
 	const handleReplySave = async (highlightId: string) => {

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -24,6 +24,24 @@ const HIGHLIGHT_BORDER_COLOR_MAP: Record<HighlightColor, string> = {
 	purple: "border-purple-400",
 };
 
+// Map highlight color names to bg color classes for the left bar
+const HIGHLIGHT_BAR_COLOR_MAP: Record<HighlightColor, string> = {
+	yellow: "bg-yellow-400",
+	green: "bg-green-500",
+	blue: "bg-blue-400",
+	pink: "bg-pink-400",
+	purple: "bg-purple-400",
+};
+
+// Map highlight color names to bubble background + border classes for annotation notes
+const BUBBLE_BG_MAP: Record<HighlightColor, string> = {
+	yellow: "bg-yellow-50 border-yellow-200 dark:bg-yellow-950/30 dark:border-yellow-800",
+	green:  "bg-green-50 border-green-200 dark:bg-green-950/30 dark:border-green-800",
+	blue:   "bg-blue-50 border-blue-200 dark:bg-blue-950/30 dark:border-blue-800",
+	pink:   "bg-pink-50 border-pink-200 dark:bg-pink-950/30 dark:border-pink-800",
+	purple: "bg-purple-50 border-purple-200 dark:bg-purple-950/30 dark:border-purple-800",
+};
+
 
 export interface AnnotationButtonProps {
 	highlightId: string;
@@ -112,32 +130,38 @@ function HighlightThread({
 	readonly,
 }: HighlightThreadProps) {
 
-	const highlightBorderColor = highlight.role === 'assistant'
-		? 'border-purple-400'
-		: HIGHLIGHT_BORDER_COLOR_MAP[highlight.color || 'blue'];
+	const barColor = highlight.role === 'assistant'
+		? 'bg-purple-400'
+		: HIGHLIGHT_BAR_COLOR_MAP[highlight.color || 'blue'];
 
 	return (
 		<div
-			className={`cursor-pointer rounded px-2 py-1.5 transition-colors ${isActive ? 'bg-secondary' : 'hover:bg-secondary/50'}`}
+			className={`cursor-pointer rounded-lg px-3 py-3 transition-colors ${isActive ? 'bg-secondary' : 'hover:bg-secondary/50'}`}
 			onClick={onClick}
 		>
-			<blockquote className={`border-l-2 ${highlightBorderColor} pl-2`}>
-				{highlight.type && (
-					<span className="text-[10px] text-purple-600 dark:text-purple-400 font-medium">
-						{highlight.type.replace('_', ' ').toLowerCase()}
-					</span>
-				)}
-				<p className="text-foreground text-sm leading-snug">
-					{highlight.raw_text}
-				</p>
-			</blockquote>
+			{/* Quoted highlight text with colored left bar */}
+			<div className="flex gap-2.5">
+				<div className={`w-0.5 rounded-full shrink-0 self-stretch ${barColor}`} />
+				<div className="min-w-0">
+					{highlight.type && (
+						<span className="text-[10px] text-purple-600 dark:text-purple-400 font-medium block mb-0.5">
+							{highlight.type.replace('_', ' ').toLowerCase()}
+						</span>
+					)}
+					<p className="text-foreground text-sm leading-snug">
+						{highlight.raw_text}
+					</p>
+				</div>
+			</div>
 
+			{/* Annotation notes */}
 			{annotations.length > 0 && (
-				<div className="space-y-1 ml-2 mt-1">
+				<div className="space-y-3 mt-3">
 					{annotations.map((annotation) => (
 						<Annotation
 							key={annotation.id}
 							annotation={{ ...annotation }}
+							highlightColor={highlight.role === 'assistant' ? 'purple' : (highlight.color || 'blue')}
 							removeAnnotation={removeAnnotation}
 							updateAnnotation={updateAnnotation}
 							user={user}
@@ -148,7 +172,7 @@ function HighlightThread({
 			)}
 
 			{isActive && !readonly && addAnnotation && highlight.id && (
-				<div className="ml-2 mt-1">
+				<div className="mt-3">
 					<AnnotationButton
 						highlightId={highlight.id}
 						addAnnotation={addAnnotation}
@@ -337,7 +361,7 @@ export function AnnotationsView(
 			/>
 
 			<div className="flex-1 overflow-auto" ref={scrollContainerRef}>
-				<div className="space-y-2 p-2">
+				<div className="space-y-1 p-2">
 					{filteredHighlights.length === 0 ? (
 						<div className="text-center text-muted-foreground text-sm py-8">
 							No highlights match the current filters.

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -9,7 +9,7 @@ import {
 import { RenderedHighlightPosition } from './PdfHighlighterViewer';
 import { smoothScrollTo } from '@/lib/animation';
 import { BasicUser } from "@/lib/auth";
-import { formatAnnotationDate } from '@/lib/utils';
+import { cn, formatAnnotationDate } from '@/lib/utils';
 import { Button } from '@/components/ui/button';
 
 const ITEM_BG_MAP: Record<HighlightColor, string> = {
@@ -19,6 +19,20 @@ const ITEM_BG_MAP: Record<HighlightColor, string> = {
 	pink:   "bg-pink-50 dark:bg-pink-950/20",
 	purple: "bg-purple-50 dark:bg-purple-950/20",
 };
+
+/** Left accent for quoted PDF snippet (matches thread highlight color). */
+const QUOTE_ACCENT_BORDER: Record<HighlightColor, string> = {
+	yellow: "border-yellow-500 dark:border-yellow-400",
+	green: "border-green-600 dark:border-green-500",
+	blue: "border-blue-500 dark:border-blue-400",
+	pink: "border-pink-500 dark:border-pink-400",
+	purple: "border-purple-500 dark:border-purple-400",
+};
+
+function highlightSwatchColor(h: PaperHighlight | undefined): HighlightColor {
+	if (!h) return "blue";
+	return h.role === "assistant" ? "purple" : (h.color || "blue");
+}
 
 /** Matches `InlineAnnotationCard` reply field — max-h-48 */
 const REPLY_TEXTAREA_MAX_PX = 192;
@@ -164,19 +178,24 @@ export function AnnotationsView({
 		}
 	}, [activeHighlight]);
 
-	// When the active highlight changes, collapse only the *previous* highlight's thread — not the
-	// newly selected one. Clearing the whole map was wiping expansion set in the same click as
-	// switching highlights (e.g. B → A required two clicks to expand A).
+	// When the active highlight changes (e.g. user clicked highlighted PDF text): expand that
+	// thread fully so "+N more replies" is not needed. When switching A→B, collapse A's expansion
+	// state and expand B.
 	useEffect(() => {
 		const id = activeHighlight?.id ?? null;
 		const prev = prevActiveIdRef.current;
-		if (prev !== null && id !== null && prev !== id) {
-			setExpandedThreads((prevMap) => {
-				const next = { ...prevMap };
+
+		setExpandedThreads((prevMap) => {
+			const next = { ...prevMap };
+			if (prev !== null && id !== null && prev !== id) {
 				delete next[prev];
-				return next;
-			});
-		}
+			}
+			if (id !== null) {
+				next[id] = true;
+			}
+			return next;
+		});
+
 		prevActiveIdRef.current = id;
 	}, [activeHighlight?.id]);
 
@@ -272,11 +291,16 @@ export function AnnotationsView({
 							New note
 						</p>
 						{composeTargetHighlight?.raw_text ? (
-							<p className="text-xs text-muted-foreground line-clamp-3 mb-2 whitespace-pre-wrap">
-								<span className="text-muted-foreground/80">&quot;</span>
-								{composeTargetHighlight.raw_text}
-								<span className="text-muted-foreground/80">&quot;</span>
-							</p>
+							<div
+								className={cn(
+									"border-l-2 pl-3 mb-2",
+									QUOTE_ACCENT_BORDER[highlightSwatchColor(composeTargetHighlight)]
+								)}
+							>
+								<p className="text-xs text-muted-foreground line-clamp-3 whitespace-pre-wrap">
+									{composeTargetHighlight.raw_text}
+								</p>
+							</div>
 						) : null}
 						<textarea
 							ref={composeTextareaRef}
@@ -355,6 +379,18 @@ export function AnnotationsView({
 								}}
 							>
 								<div className="flex flex-col gap-3">
+									{highlight.raw_text?.trim() ? (
+										<div
+											className={cn(
+												"border-l-2 pl-3 mb-0",
+												QUOTE_ACCENT_BORDER[color]
+											)}
+										>
+											<p className="text-xs text-muted-foreground line-clamp-3 whitespace-pre-wrap">
+												{highlight.raw_text}
+											</p>
+										</div>
+									) : null}
 									{visible.map((annotation) => (
 										<div key={annotation.id} className="flex flex-col gap-2">
 											<div className="flex items-center gap-2">

--- a/client/src/components/AnnotationsView.tsx
+++ b/client/src/components/AnnotationsView.tsx
@@ -45,14 +45,17 @@ const BUBBLE_BG_MAP: Record<HighlightColor, string> = {
 
 export interface AnnotationButtonProps {
 	highlightId: string;
-	// Make addAnnotation optional as it might not be needed in readonly
 	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
+	user?: BasicUser;
 }
 
-export function AnnotationButton({ highlightId, addAnnotation }: AnnotationButtonProps) {
+export function AnnotationButton({ highlightId, addAnnotation, user }: AnnotationButtonProps) {
 	const [content, setContent] = useState("");
 	const [isTyping, setIsTyping] = useState(false);
 	const [isAdding, setIsAdding] = useState(false);
+
+	const now = new Date();
+	const timeStr = now.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 
 	const handleSave = async () => {
 		if (content.trim() && addAnnotation) {
@@ -73,6 +76,20 @@ export function AnnotationButton({ highlightId, addAnnotation }: AnnotationButto
 
 	return (
 		<div className="mt-1">
+			{/* Avatar row */}
+			<div className="flex items-center gap-2 mb-2">
+				<div className="w-8 h-8 rounded-full flex items-center justify-center flex-shrink-0 overflow-hidden bg-muted">
+					{user?.picture ? (
+						// eslint-disable-next-line @next/next/no-img-element
+						<img src={user.picture} alt={user.name} className="w-full h-full object-cover" />
+					) : (
+						<UserIcon size={14} className="text-muted-foreground" />
+					)}
+				</div>
+				<span className="text-sm font-medium text-foreground">{user?.name || 'User'}</span>
+				<span className="text-xs text-muted-foreground">{timeStr}</span>
+			</div>
+
 			<Textarea
 				value={content}
 				onChange={(e) => {
@@ -86,7 +103,7 @@ export function AnnotationButton({ highlightId, addAnnotation }: AnnotationButto
 					}
 				})}
 				placeholder="Store your thoughts here."
-				className="text-sm"
+				className="ml-10 w-[calc(100%-2.5rem)] text-sm focus:ring-0 focus-visible:ring-0 focus-visible:ring-offset-0 focus:border-foreground focus-visible:border-foreground"
 				rows={3}
 				autoFocus
 			/>
@@ -176,6 +193,7 @@ function HighlightThread({
 					<AnnotationButton
 						highlightId={highlight.id}
 						addAnnotation={addAnnotation}
+						user={user}
 					/>
 				</div>
 			)}

--- a/client/src/components/CitePaperButton.tsx
+++ b/client/src/components/CitePaperButton.tsx
@@ -24,9 +24,10 @@ interface CitePaperButtonProps {
     paperId?: string;
     minimalist?: boolean;
     variant?: "ghost" | "outline";
+    iconOnly?: boolean;
 }
 
-export function CitePaperButton({ paper, paperId: providedPaperId, minimalist = false, variant = "ghost" }: CitePaperButtonProps) {
+export function CitePaperButton({ paper, paperId: providedPaperId, minimalist = false, variant = "ghost", iconOnly = false }: CitePaperButtonProps) {
     const pathname = usePathname();
     const [derivedPaperId, setDerivedPaperId] = useState<string | null>(null);
     const [paperData, setPaperData] = useState<(PaperData | PaperItem)[] | null>(paper || null);
@@ -97,7 +98,11 @@ export function CitePaperButton({ paper, paperId: providedPaperId, minimalist = 
         return null;
     }
 
-    const triggerButton = (
+    const triggerButton = iconOnly ? (
+        <Button variant="ghost" className="h-10 w-10 p-0">
+            <Quote className="h-5 w-5" />
+        </Button>
+    ) : (
         <Button variant={variant} size="sm" className={variant === "outline" ? "h-8 px-3 text-xs" : ""}>
             {(!minimalist || variant === "outline") && <Quote className="h-3.5 w-3.5 mr-1.5" />}
             <span className={minimalist && variant !== "outline" ? "text-sm" : ""}>{isBibliography ? 'Bibliography' : 'Cite'}</span>

--- a/client/src/components/CitePaperButton.tsx
+++ b/client/src/components/CitePaperButton.tsx
@@ -99,7 +99,7 @@ export function CitePaperButton({ paper, paperId: providedPaperId, minimalist = 
     }
 
     const triggerButton = iconOnly ? (
-        <Button variant="ghost" className="h-7 w-7 p-0 rounded-md text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800">
+        <Button variant="ghost" className="h-7 w-7 p-0 rounded-md text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground">
             <Quote className="h-4 w-4" />
         </Button>
     ) : (

--- a/client/src/components/CitePaperButton.tsx
+++ b/client/src/components/CitePaperButton.tsx
@@ -99,7 +99,7 @@ export function CitePaperButton({ paper, paperId: providedPaperId, minimalist = 
     }
 
     const triggerButton = iconOnly ? (
-        <Button variant="ghost" className="h-10 w-10 p-0">
+        <Button variant="ghost" className="h-10 w-10 p-0 rounded-md text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800">
             <Quote className="h-5 w-5" />
         </Button>
     ) : (

--- a/client/src/components/CitePaperButton.tsx
+++ b/client/src/components/CitePaperButton.tsx
@@ -1,16 +1,8 @@
 "use client";
 
-import React, { useState, useEffect } from 'react';
-import { usePathname } from 'next/navigation';
-import { Quote, Loader, Copy, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
-import { toast } from 'sonner';
-import { fetchFromApi } from '@/lib/api';
-import { PaperData, PaperItem } from '@/lib/schema';
-import { useIsMobile } from '@/hooks/use-mobile';
-import { citationStyles, copyToClipboard, PaperBase } from '@/components/utils/paperUtils';
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer';
 import {
     Select,
     SelectContent,
@@ -18,6 +10,14 @@ import {
     SelectTrigger,
     SelectValue,
 } from "@/components/ui/select";
+import { citationStyles, copyToClipboard, PaperBase } from '@/components/utils/paperUtils';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { fetchFromApi } from '@/lib/api';
+import { PaperData, PaperItem } from '@/lib/schema';
+import { Check, Copy, Loader, Quote } from 'lucide-react';
+import { usePathname } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 interface CitePaperButtonProps {
     paper?: (PaperData | PaperItem)[];
@@ -99,8 +99,8 @@ export function CitePaperButton({ paper, paperId: providedPaperId, minimalist = 
     }
 
     const triggerButton = iconOnly ? (
-        <Button variant="ghost" className="h-10 w-10 p-0 rounded-md text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800">
-            <Quote className="h-5 w-5" />
+        <Button variant="ghost" className="h-7 w-7 p-0 rounded-md text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800">
+            <Quote className="h-4 w-4" />
         </Button>
     ) : (
         <Button variant={variant} size="sm" className={variant === "outline" ? "h-8 px-3 text-xs" : ""}>

--- a/client/src/components/CollapsibleNoteText.tsx
+++ b/client/src/components/CollapsibleNoteText.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+
+const defaultParagraphClass =
+	"text-sm text-foreground whitespace-pre-wrap break-words";
+
+export function CollapsibleNoteText({
+	content,
+	isActive = true,
+	paragraphClassName,
+	onExpandToggle,
+}: {
+	content: string;
+	/** When false, collapses expanded text (e.g. inactive inline card or sidebar row). */
+	isActive?: boolean;
+	paragraphClassName?: string;
+	/** Optional hook when user toggles show more/less (e.g. focus parent highlight). */
+	onExpandToggle?: () => void;
+}) {
+	const [expanded, setExpanded] = useState(false);
+	const [collapsedOverflow, setCollapsedOverflow] = useState(false);
+	const pRef = useRef<HTMLParagraphElement>(null);
+
+	useEffect(() => {
+		if (isActive === false) setExpanded(false);
+	}, [isActive]);
+
+	useLayoutEffect(() => {
+		const el = pRef.current;
+		if (!el || expanded) return;
+
+		const measure = () => {
+			setCollapsedOverflow(el.scrollHeight > el.clientHeight);
+		};
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [content, expanded]);
+
+	const showToggle = expanded || collapsedOverflow;
+	const pClass = paragraphClassName ?? defaultParagraphClass;
+
+	return (
+		<div className="min-w-0 w-full">
+			<p
+				ref={pRef}
+				className={cn(pClass, !expanded && "line-clamp-4")}
+			>
+				{content}
+			</p>
+			{showToggle && (
+				<button
+					type="button"
+					className="text-xs text-blue-600 hover:underline dark:text-blue-400 mt-1"
+					onClick={(e) => {
+						e.stopPropagation();
+						onExpandToggle?.();
+						setExpanded((v) => !v);
+					}}
+					onMouseDown={(e) => e.stopPropagation()}
+				>
+					{expanded ? "Show less" : "Show more"}
+				</button>
+			)}
+		</div>
+	);
+}

--- a/client/src/components/ConversationView.tsx
+++ b/client/src/components/ConversationView.tsx
@@ -536,6 +536,7 @@ export const ConversationView = ({
 								setUserMessageReferences={() => { }}
 								setSelectedText={() => { }}
 								setTooltipPosition={() => { }}
+								isAnnotating={false}
 								setIsAnnotating={() => { }}
 								setIsHighlightInteraction={() => { }}
 								isHighlightInteraction={false}

--- a/client/src/components/InlineAnnotationCard.tsx
+++ b/client/src/components/InlineAnnotationCard.tsx
@@ -16,7 +16,8 @@ interface InlineAnnotationCardProps {
     annotationId?: string;
     isActive?: boolean;
     user: BasicUser | null;
-    addAnnotation: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
+    /** When omitted, card is display-only (e.g. share / preview); no create or save. */
+    addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
     updateAnnotation?: (annotationId: string, content: string) => Promise<unknown> | void;
     onAnnotationSaved?: (annotationId: string) => void;
     onDelete?: () => void;
@@ -41,7 +42,10 @@ export function InlineAnnotationCard({
 }: InlineAnnotationCardProps) {
     const [content, setContent] = useState(initialContent ?? "");
     const [isSaving, setIsSaving] = useState(false);
-    const [isEditing, setIsEditing] = useState(!initialContent);
+    const canCreateOrEdit = annotationId
+        ? Boolean(updateAnnotation)
+        : Boolean(addAnnotation);
+    const [isEditing, setIsEditing] = useState(!initialContent && canCreateOrEdit);
     const cardRef = useRef<HTMLDivElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -51,11 +55,16 @@ export function InlineAnnotationCard({
 
     const handleSave = async () => {
         if (!content.trim() || isSaving) return;
+        if (annotationId) {
+            if (!updateAnnotation) return;
+        } else if (!addAnnotation) {
+            return;
+        }
         setIsSaving(true);
         try {
             if (annotationId && updateAnnotation) {
                 await updateAnnotation(annotationId, content.trim());
-            } else {
+            } else if (addAnnotation) {
                 const result = await addAnnotation(highlightId, content.trim());
                 onAnnotationSaved?.(result.id);
             }
@@ -97,11 +106,15 @@ export function InlineAnnotationCard({
         return () => ro.disconnect();
     }, [onHeightChange]);
 
-    // Outside click: close only if nothing has been typed; otherwise collapse to read mode
+        // Outside click: for persistent (saved) cards, only collapse to read mode.
+        // For new unsaved cards, close if nothing has been typed; otherwise collapse.
     useEffect(() => {
         const handleOutsideClick = (e: MouseEvent) => {
             if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
-                if (!content.trim()) {
+                if (annotationId) {
+                    // Saved annotation — never close via outside click; only collapse if editing
+                    if (isEditing) setIsEditing(false);
+                } else if (!content.trim()) {
                     onClose();
                 } else if (isEditing) {
                     setIsEditing(false);
@@ -115,7 +128,7 @@ export function InlineAnnotationCard({
             clearTimeout(timerId);
             document.removeEventListener("mousedown", handleOutsideClick);
         };
-    }, [onClose, content, isEditing]);
+    }, [onClose, content, isEditing, annotationId]);
 
     const displayName = user?.name || "Anonymous";
     const avatarBg = user?.name ? getAlphaHashToBackgroundColor(user.name) : "bg-muted";
@@ -146,7 +159,7 @@ export function InlineAnnotationCard({
 
                 {/* Action icons */}
                 <div className="flex items-center gap-0.5 flex-shrink-0">
-                    {!isEditing && (
+                    {!isEditing && canCreateOrEdit && (
                         <>
                             <Button
                                 variant="ghost"
@@ -158,12 +171,12 @@ export function InlineAnnotationCard({
                             >
                                 <Pencil size={13} />
                             </Button>
-                            {annotationId && (
+                            {annotationId && onDelete && (
                                 <Button
                                     variant="ghost"
                                     size="icon"
                                     className="h-6 w-6 text-muted-foreground hover:text-destructive"
-                                    onClick={(e) => { e.stopPropagation(); onDelete?.(); }}
+                                    onClick={(e) => { e.stopPropagation(); onDelete(); }}
                                     onMouseDown={(e) => e.stopPropagation()}
                                     title="Delete"
                                 >
@@ -172,16 +185,19 @@ export function InlineAnnotationCard({
                             )}
                         </>
                     )}
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                        onClick={(e) => { e.stopPropagation(); onClose(); }}
-                        onMouseDown={(e) => e.stopPropagation()}
-                        title="Close"
-                    >
-                        <X size={14} />
-                    </Button>
+                    {/* X button only for unsaved (new) annotation cards — saved cards use Delete */}
+                    {!annotationId && addAnnotation && (
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                            onClick={(e) => { e.stopPropagation(); onClose(); }}
+                            onMouseDown={(e) => e.stopPropagation()}
+                            title="Close"
+                        >
+                            <X size={14} />
+                        </Button>
+                    )}
                 </div>
             </div>
 

--- a/client/src/components/InlineAnnotationCard.tsx
+++ b/client/src/components/InlineAnnotationCard.tsx
@@ -8,6 +8,68 @@ import { cn, formatAnnotationDate, getAlphaHashToBackgroundColor, getInitials } 
 import { Pencil, Trash2, X } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
+/** Read-only note body: clamps long text and offers Show more / Show less (overflow measured). */
+function CollapsibleNoteText({
+	content,
+	isActive,
+	onCardFocus,
+}: {
+	content: string;
+	isActive: boolean;
+	onCardFocus?: () => void;
+}) {
+	const [expanded, setExpanded] = useState(false);
+	const [collapsedOverflow, setCollapsedOverflow] = useState(false);
+	const pRef = useRef<HTMLParagraphElement>(null);
+
+	useEffect(() => {
+		if (!isActive) setExpanded(false);
+	}, [isActive]);
+
+	useLayoutEffect(() => {
+		const el = pRef.current;
+		if (!el || expanded) return;
+
+		const measure = () => {
+			setCollapsedOverflow(el.scrollHeight > el.clientHeight);
+		};
+		measure();
+		const ro = new ResizeObserver(measure);
+		ro.observe(el);
+		return () => ro.disconnect();
+	}, [content, expanded]);
+
+	const showToggle = expanded || collapsedOverflow;
+
+	return (
+		<div className="min-w-0 w-full">
+			<p
+				ref={pRef}
+				className={cn(
+					"text-sm text-foreground whitespace-pre-wrap break-words",
+					!expanded && "line-clamp-4"
+				)}
+			>
+				{content}
+			</p>
+			{showToggle && (
+				<button
+					type="button"
+					className="text-xs text-blue-600 hover:underline dark:text-blue-400 mt-1"
+					onClick={(e) => {
+						e.stopPropagation();
+						onCardFocus?.();
+						setExpanded((v) => !v);
+					}}
+					onMouseDown={(e) => e.stopPropagation()}
+				>
+					{expanded ? "Show less" : "Show more"}
+				</button>
+			)}
+		</div>
+	);
+}
+
 interface InlineAnnotationCardProps {
     highlightId: string;
     topPosition: number;
@@ -463,7 +525,11 @@ export function InlineAnnotationCard({
                                         </div>
                                     </div>
                                 ) : (
-                                    <p className="text-sm text-foreground whitespace-pre-wrap">{ann.content}</p>
+                                    <CollapsibleNoteText
+                                        content={ann.content}
+                                        isActive={isActive}
+                                        onCardFocus={onCardFocus}
+                                    />
                                 )}
                             </div>
                         ))}

--- a/client/src/components/InlineAnnotationCard.tsx
+++ b/client/src/components/InlineAnnotationCard.tsx
@@ -5,70 +5,9 @@ import { Button } from "@/components/ui/button";
 import { BasicUser } from "@/lib/auth";
 import { PaperHighlightAnnotation } from "@/lib/schema";
 import { cn, formatAnnotationDate, getAlphaHashToBackgroundColor, getInitials } from "@/lib/utils";
+import { CollapsibleNoteText } from "@/components/CollapsibleNoteText";
 import { Pencil, Trash2, X } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-
-/** Read-only note body: clamps long text and offers Show more / Show less (overflow measured). */
-function CollapsibleNoteText({
-	content,
-	isActive,
-	onCardFocus,
-}: {
-	content: string;
-	isActive: boolean;
-	onCardFocus?: () => void;
-}) {
-	const [expanded, setExpanded] = useState(false);
-	const [collapsedOverflow, setCollapsedOverflow] = useState(false);
-	const pRef = useRef<HTMLParagraphElement>(null);
-
-	useEffect(() => {
-		if (!isActive) setExpanded(false);
-	}, [isActive]);
-
-	useLayoutEffect(() => {
-		const el = pRef.current;
-		if (!el || expanded) return;
-
-		const measure = () => {
-			setCollapsedOverflow(el.scrollHeight > el.clientHeight);
-		};
-		measure();
-		const ro = new ResizeObserver(measure);
-		ro.observe(el);
-		return () => ro.disconnect();
-	}, [content, expanded]);
-
-	const showToggle = expanded || collapsedOverflow;
-
-	return (
-		<div className="min-w-0 w-full">
-			<p
-				ref={pRef}
-				className={cn(
-					"text-sm text-foreground whitespace-pre-wrap break-words",
-					!expanded && "line-clamp-4"
-				)}
-			>
-				{content}
-			</p>
-			{showToggle && (
-				<button
-					type="button"
-					className="text-xs text-blue-600 hover:underline dark:text-blue-400 mt-1"
-					onClick={(e) => {
-						e.stopPropagation();
-						onCardFocus?.();
-						setExpanded((v) => !v);
-					}}
-					onMouseDown={(e) => e.stopPropagation()}
-				>
-					{expanded ? "Show less" : "Show more"}
-				</button>
-			)}
-		</div>
-	);
-}
 
 interface InlineAnnotationCardProps {
     highlightId: string;
@@ -528,7 +467,7 @@ export function InlineAnnotationCard({
                                     <CollapsibleNoteText
                                         content={ann.content}
                                         isActive={isActive}
-                                        onCardFocus={onCardFocus}
+                                        onExpandToggle={onCardFocus}
                                     />
                                 )}
                             </div>

--- a/client/src/components/InlineAnnotationCard.tsx
+++ b/client/src/components/InlineAnnotationCard.tsx
@@ -4,98 +4,91 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { BasicUser } from "@/lib/auth";
 import { PaperHighlightAnnotation } from "@/lib/schema";
-import { getAlphaHashToBackgroundColor, getInitials } from "@/lib/utils";
+import { cn, getAlphaHashToBackgroundColor, getInitials, formatDate } from "@/lib/utils";
 import { Pencil, Trash2, X } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
 interface InlineAnnotationCardProps {
     highlightId: string;
     topPosition: number;
     leftPosition: number;
-    initialContent?: string;
-    annotationId?: string;
+    annotations: PaperHighlightAnnotation[];
     isActive?: boolean;
     user: BasicUser | null;
     /** When omitted, card is display-only (e.g. share / preview); no create or save. */
     addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
     updateAnnotation?: (annotationId: string, content: string) => Promise<unknown> | void;
+    removeAnnotation?: (annotationId: string) => void;
     onAnnotationSaved?: (annotationId: string) => void;
-    onDelete?: () => void;
     onClose: () => void;
     onHeightChange?: (height: number) => void;
+    /** Called when the user interacts with the card so the parent can mark this highlight active (e.g. show reply UI). */
+    onCardFocus?: () => void;
 }
 
 export function InlineAnnotationCard({
     highlightId,
     topPosition,
     leftPosition,
-    initialContent,
-    annotationId,
+    annotations,
     isActive = false,
     user,
     addAnnotation,
     updateAnnotation,
+    removeAnnotation,
     onAnnotationSaved,
-    onDelete,
     onClose,
     onHeightChange,
+    onCardFocus,
 }: InlineAnnotationCardProps) {
-    const [content, setContent] = useState(initialContent ?? "");
+    const isNewThread = annotations.length === 0;
+    const canWrite = Boolean(addAnnotation);
+
+    // State for the new-thread textarea (when no annotations exist yet)
+    const [newContent, setNewContent] = useState("");
+    // State for the reply textarea (when thread already has comments)
+    const [replyContent, setReplyContent] = useState("");
+    // Whether the reply composer is expanded (false = collapsed pill)
+    const [isReplyOpen, setIsReplyOpen] = useState(false);
+    // Which annotation is currently being edited in-place
+    const [editingId, setEditingId] = useState<string | null>(null);
+    const [editContent, setEditContent] = useState("");
     const [isSaving, setIsSaving] = useState(false);
-    const canCreateOrEdit = annotationId
-        ? Boolean(updateAnnotation)
-        : Boolean(addAnnotation);
-    const [isEditing, setIsEditing] = useState(!initialContent && canCreateOrEdit);
+    /** When there are multiple comments, show only the first until the user expands the thread */
+    const [threadExpanded, setThreadExpanded] = useState(false);
+
     const cardRef = useRef<HTMLDivElement>(null);
-    const textareaRef = useRef<HTMLTextAreaElement>(null);
+    const newTextareaRef = useRef<HTMLTextAreaElement>(null);
+    const replyTextareaRef = useRef<HTMLTextAreaElement>(null);
+    const editTextareaRef = useRef<HTMLTextAreaElement>(null);
+    /** Wrapper around the in-place edit textarea; used to detect “click outside” to cancel edit */
+    const editBlockRef = useRef<HTMLDivElement>(null);
+    /** Reply row (pill or expanded); used to collapse reply when clicking elsewhere on the card */
+    const replySectionRef = useRef<HTMLDivElement>(null);
 
-    const now = new Date();
-    const timeStr = now.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
-    const timestamp = `${timeStr} Today`;
+    const displayName = user?.name || "Anonymous";
+    const avatarBg = user?.name ? getAlphaHashToBackgroundColor(user.name) : "bg-muted";
 
-    const handleSave = async () => {
-        if (!content.trim() || isSaving) return;
-        if (annotationId) {
-            if (!updateAnnotation) return;
-        } else if (!addAnnotation) {
-            return;
-        }
-        setIsSaving(true);
-        try {
-            if (annotationId && updateAnnotation) {
-                await updateAnnotation(annotationId, content.trim());
-            } else if (addAnnotation) {
-                const result = await addAnnotation(highlightId, content.trim());
-                onAnnotationSaved?.(result.id);
-            }
-            setIsEditing(false);
-        } finally {
-            setIsSaving(false);
-        }
-    };
+    const sortedThread = useMemo(
+        () =>
+            [...annotations].sort(
+                (a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+            ),
+        [annotations]
+    );
+    const hasMultiComment = sortedThread.length > 1;
+    const visibleThread =
+        !hasMultiComment || threadExpanded ? sortedThread : sortedThread.slice(0, 1);
+    const moreCount = hasMultiComment && !threadExpanded ? sortedThread.length - 1 : 0;
 
-    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-        if (e.key === "Enter" && !e.shiftKey) {
-            e.preventDefault();
-            handleSave();
-        } else if (e.key === "Escape") {
-            onClose();
-        }
-    };
-
-    // Focus textarea and auto-size it to full content height when entering edit mode
+    // Auto-focus the new-thread textarea on mount when there are no annotations
     useEffect(() => {
-        if (isEditing && textareaRef.current) {
-            const el = textareaRef.current;
-            el.style.height = 'auto';
-            el.style.height = `${el.scrollHeight}px`;
-            el.focus();
-            const len = el.value.length;
-            el.setSelectionRange(len, len);
+        if (isNewThread && canWrite && newTextareaRef.current) {
+            newTextareaRef.current.focus();
         }
-    }, [isEditing]);
+    }, [isNewThread, canWrite]);
 
-    // Report actual card height to parent whenever it changes (e.g. edit mode toggle, long text)
+    // Report actual card height to parent whenever it changes
     useEffect(() => {
         const el = cardRef.current;
         if (!el || !onHeightChange) return;
@@ -106,18 +99,18 @@ export function InlineAnnotationCard({
         return () => ro.disconnect();
     }, [onHeightChange]);
 
-        // Outside click: for persistent (saved) cards, only collapse to read mode.
-        // For new unsaved cards, close if nothing has been typed; otherwise collapse.
+    // Outside click: for cards with saved annotations, only collapse editing/reply state.
+    // For new unsaved cards, close if nothing has been typed; otherwise collapse.
     useEffect(() => {
         const handleOutsideClick = (e: MouseEvent) => {
             if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
-                if (annotationId) {
-                    // Saved annotation — never close via outside click; only collapse if editing
-                    if (isEditing) setIsEditing(false);
-                } else if (!content.trim()) {
+                if (!isNewThread) {
+                    // Thread exists — never auto-close via outside click
+                    setEditingId(null);
+                    // Collapse reply to pill (draft kept in replyContent for next open)
+                    setIsReplyOpen(false);
+                } else if (!newContent.trim()) {
                     onClose();
-                } else if (isEditing) {
-                    setIsEditing(false);
                 }
             }
         };
@@ -128,96 +121,361 @@ export function InlineAnnotationCard({
             clearTimeout(timerId);
             document.removeEventListener("mousedown", handleOutsideClick);
         };
-    }, [onClose, content, isEditing, annotationId]);
+    }, [onClose, newContent, isNewThread]);
 
-    const displayName = user?.name || "Anonymous";
-    const avatarBg = user?.name ? getAlphaHashToBackgroundColor(user.name) : "bg-muted";
+    // Editing an existing comment: hide the expanded reply composer (bordered textarea) so only
+    // one bordered field is visible at a time.
+    useEffect(() => {
+        if (editingId) setIsReplyOpen(false);
+    }, [editingId]);
+
+    // Cancel in-place edit on mousedown outside the edit textarea. Use capture so we still run
+    // when the card stops propagation on bubble (clicks inside the card never reach document).
+    useEffect(() => {
+        if (!editingId) return;
+        const handleMouseDown = (e: MouseEvent) => {
+            const el = editBlockRef.current;
+            if (el && !el.contains(e.target as Node)) {
+                setEditingId(null);
+            }
+        };
+        document.addEventListener("mousedown", handleMouseDown, true);
+        return () => document.removeEventListener("mousedown", handleMouseDown, true);
+    }, [editingId]);
+
+    // Collapse expanded reply when mousedown happens outside the reply section (capture phase).
+    useEffect(() => {
+        if (!isReplyOpen) return;
+        const handleMouseDown = (e: MouseEvent) => {
+            const el = replySectionRef.current;
+            if (el && !el.contains(e.target as Node)) {
+                setIsReplyOpen(false);
+            }
+        };
+        document.addEventListener("mousedown", handleMouseDown, true);
+        return () => document.removeEventListener("mousedown", handleMouseDown, true);
+    }, [isReplyOpen]);
+
+    // When inactive: hide reply UI and collapse thread preview. When active (e.g. user clicked
+    // the highlight in the PDF), expand multi-comment threads so the full conversation shows.
+    useEffect(() => {
+        if (!isActive) {
+            setIsReplyOpen(false);
+            setReplyContent("");
+            setEditingId(null);
+            setThreadExpanded(false);
+        } else if (hasMultiComment) {
+            setThreadExpanded(true);
+        }
+    }, [isActive, hasMultiComment]);
+
+    // ── Save handlers ──────────────────────────────────────────────────────────
+
+    const handleSaveNew = async () => {
+        if (!newContent.trim() || isSaving || !addAnnotation) return;
+        setIsSaving(true);
+        try {
+            const result = await addAnnotation(highlightId, newContent.trim());
+            onAnnotationSaved?.(result.id);
+            setNewContent("");
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleSaveReply = async () => {
+        if (!replyContent.trim() || isSaving || !addAnnotation) return;
+        setIsSaving(true);
+        try {
+            await addAnnotation(highlightId, replyContent.trim());
+            setReplyContent("");
+            setIsReplyOpen(false);
+            setThreadExpanded(true);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleSaveEdit = async (annotationId: string) => {
+        if (!editContent.trim() || isSaving || !updateAnnotation) return;
+        setIsSaving(true);
+        try {
+            await updateAnnotation(annotationId, editContent.trim());
+            setEditingId(null);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleDeleteComment = (annotationId: string) => {
+        removeAnnotation?.(annotationId);
+    };
+
+    // ── Keyboard handlers ──────────────────────────────────────────────────────
+
+    const handleNewKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSaveNew();
+        } else if (e.key === "Escape") {
+            onClose();
+        }
+    };
+
+    const handleReplyKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSaveReply();
+        } else if (e.key === "Escape") {
+            setReplyContent("");
+            setIsReplyOpen(false);
+        }
+    };
+
+    const handleEditKeyDown = (annotationId: string) => (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSaveEdit(annotationId);
+        } else if (e.key === "Escape") {
+            setEditingId(null);
+        }
+    };
+
+    // ── Auto-resize helper ─────────────────────────────────────────────────────
+
+    /** Bordered comment fields: grow with content up to max height, then scroll inside */
+    const CONTAINED_TEXTAREA_MAX_PX = 192; // matches max-h-48
+    const autoResizeContained = (el: HTMLTextAreaElement) => {
+        el.style.height = "auto";
+        el.style.height = `${Math.min(el.scrollHeight, CONTAINED_TEXTAREA_MAX_PX)}px`;
+    };
+
+    useLayoutEffect(() => {
+        if (editingId && editTextareaRef.current) {
+            autoResizeContained(editTextareaRef.current);
+        }
+    }, [editingId]);
+
+    // ── Render ─────────────────────────────────────────────────────────────────
 
     return (
         <div
             ref={cardRef}
-            className={`absolute z-40 w-[280px] border border-border rounded-xl shadow-lg p-4 flex flex-col gap-3 transition-colors duration-200 ${isActive ? "bg-background" : "bg-[#ebebeb] dark:bg-zinc-800"}`}
+            data-inline-annotation-card=""
+            className={`absolute z-40 w-[280px] border border-border rounded-xl shadow-lg flex flex-col transition-[top,left,background-color,border-color] duration-200 ease-out motion-reduce:transition-none overflow-hidden ${isActive ? "bg-background" : "bg-[#ebebeb] dark:bg-zinc-800"}`}
             style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
             onClick={(e) => e.stopPropagation()}
-            onMouseDown={(e) => e.stopPropagation()}
+            onMouseDown={(e) => {
+                e.stopPropagation();
+                onCardFocus?.();
+                if (hasMultiComment && !threadExpanded) setThreadExpanded(true);
+            }}
         >
-            {/* Header: avatar + name/timestamp + action icons */}
-            <div className="flex items-center gap-3">
-                <Avatar className="h-9 w-9 flex-shrink-0">
-                    {user?.picture && <AvatarImage src={user.picture} alt={displayName} />}
-                    <AvatarFallback
-                        className="text-xs text-white font-medium"
-                        style={{ backgroundColor: avatarBg }}
-                    >
-                        {getInitials(displayName)}
-                    </AvatarFallback>
-                </Avatar>
-                <div className="flex flex-col leading-tight flex-1 min-w-0">
-                    <span className="text-sm font-medium">{displayName}</span>
-                    <span className="text-xs text-muted-foreground">{timestamp}</span>
-                </div>
-
-                {/* Action icons */}
-                <div className="flex items-center gap-0.5 flex-shrink-0">
-                    {!isEditing && canCreateOrEdit && (
-                        <>
+            {isNewThread ? (
+                /* ── New thread: single composer ─────────────────────────── */
+                <div className="p-4 flex flex-col gap-3">
+                    <div className="flex items-center gap-3">
+                        <Avatar className="h-9 w-9 flex-shrink-0">
+                            {user?.picture && <AvatarImage src={user.picture} alt={displayName} />}
+                            <AvatarFallback
+                                className="text-xs text-white font-medium"
+                                style={{ backgroundColor: avatarBg }}
+                            >
+                                {getInitials(displayName)}
+                            </AvatarFallback>
+                        </Avatar>
+                        <div className="flex flex-col leading-tight flex-1 min-w-0">
+                            <span className="text-sm font-medium">{displayName}</span>
+                            <span className="text-xs text-muted-foreground">Just now</span>
+                        </div>
+                        {canWrite && (
                             <Button
                                 variant="ghost"
                                 size="icon"
-                                className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                                onClick={(e) => { e.stopPropagation(); setIsEditing(true); }}
+                                className="h-6 w-6 text-muted-foreground hover:text-foreground flex-shrink-0"
+                                onClick={(e) => { e.stopPropagation(); onClose(); }}
                                 onMouseDown={(e) => e.stopPropagation()}
-                                title="Edit"
+                                title="Close"
                             >
-                                <Pencil size={13} />
+                                <X size={14} />
                             </Button>
-                            {annotationId && onDelete && (
-                                <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    className="h-6 w-6 text-muted-foreground hover:text-destructive"
-                                    onClick={(e) => { e.stopPropagation(); onDelete(); }}
-                                    onMouseDown={(e) => e.stopPropagation()}
-                                    title="Delete"
-                                >
-                                    <Trash2 size={13} />
-                                </Button>
-                            )}
-                        </>
-                    )}
-                    {/* X button only for unsaved (new) annotation cards — saved cards use Delete */}
-                    {!annotationId && addAnnotation && (
-                        <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-6 w-6 text-muted-foreground hover:text-foreground"
-                            onClick={(e) => { e.stopPropagation(); onClose(); }}
-                            onMouseDown={(e) => e.stopPropagation()}
-                            title="Close"
-                        >
-                            <X size={14} />
-                        </Button>
+                        )}
+                    </div>
+                    {canWrite ? (
+                        <textarea
+                            ref={newTextareaRef}
+                            value={newContent}
+                            onChange={(e) => {
+                                setNewContent(e.target.value);
+                                autoResizeContained(e.target);
+                            }}
+                            onKeyDown={handleNewKeyDown}
+                            placeholder="Write your notes here and press Enter to save"
+                            aria-label="New annotation"
+                            className="text-sm text-foreground placeholder:text-muted-foreground resize-none w-full min-h-[4rem] max-h-48 px-3 py-2 overflow-y-auto overflow-x-hidden box-border rounded-md border border-black bg-background focus:outline-none focus:ring-0 focus:border-black dark:border-white dark:focus:border-white"
+                            disabled={isSaving}
+                            rows={3}
+                        />
+                    ) : (
+                        <p className="text-sm text-muted-foreground italic">No annotation yet.</p>
                     )}
                 </div>
-            </div>
-
-            {/* Annotation — editable textarea in edit mode, plain text in read mode */}
-            {isEditing ? (
-                <textarea
-                    ref={textareaRef}
-                    value={content}
-                    onChange={(e) => {
-                        setContent(e.target.value);
-                        e.target.style.height = 'auto';
-                        e.target.style.height = `${e.target.scrollHeight}px`;
-                    }}
-                    onKeyDown={handleKeyDown}
-                    placeholder="Write your notes here and press Enter to save"
-                    className="text-sm text-foreground placeholder:text-muted-foreground resize-none bg-transparent border-none outline-none w-full min-h-0 p-0 focus:outline-none overflow-hidden"
-                    disabled={isSaving}
-                />
             ) : (
-                <p className="text-sm text-foreground whitespace-pre-wrap">{content}</p>
+                /* ── Existing thread (one card; optional collapse to first comment) ─ */
+                <>
+                    <div
+                        className={cn(
+                            "px-4 pt-4 flex flex-col gap-3",
+                            canWrite && isActive ? "pb-2" : "pb-4"
+                        )}
+                    >
+                        {visibleThread.map((ann) => (
+                            <div key={ann.id} className="flex flex-col gap-2">
+                                <div className="flex items-center gap-3">
+                                    <Avatar className="h-7 w-7 flex-shrink-0">
+                                        {user?.picture && <AvatarImage src={user.picture} alt={displayName} />}
+                                        <AvatarFallback
+                                            className="text-[10px] text-white font-medium"
+                                            style={{ backgroundColor: avatarBg }}
+                                        >
+                                            {getInitials(displayName)}
+                                        </AvatarFallback>
+                                    </Avatar>
+                                    <div className="flex flex-col leading-tight flex-1 min-w-0">
+                                        <span className="text-xs font-medium">{displayName}</span>
+                                        <span className="text-[11px] text-muted-foreground">{formatDate(ann.created_at)}</span>
+                                    </div>
+                                    {ann.role === "user" && isActive && (
+                                        <div className="flex items-center gap-0.5 flex-shrink-0">
+                                            {updateAnnotation && (
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        onCardFocus?.();
+                                                        setThreadExpanded(true);
+                                                        setEditingId(ann.id);
+                                                        setEditContent(ann.content);
+                                                    }}
+                                                    onMouseDown={(e) => e.stopPropagation()}
+                                                    title="Edit"
+                                                >
+                                                    <Pencil size={12} />
+                                                </Button>
+                                            )}
+                                            {removeAnnotation && (
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        onCardFocus?.();
+                                                        handleDeleteComment(ann.id);
+                                                    }}
+                                                    onMouseDown={(e) => e.stopPropagation()}
+                                                    title="Delete"
+                                                >
+                                                    <Trash2 size={12} />
+                                                </Button>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
+                                {editingId === ann.id ? (
+                                    <div ref={editBlockRef} className="w-full min-w-0">
+                                        <textarea
+                                            ref={editTextareaRef}
+                                            autoFocus
+                                            value={editContent}
+                                            onChange={(e) => {
+                                                setEditContent(e.target.value);
+                                                autoResizeContained(e.target);
+                                            }}
+                                            onKeyDown={handleEditKeyDown(ann.id)}
+                                            aria-label="Edit comment"
+                                            className="text-sm text-foreground resize-none w-full min-h-[4rem] max-h-48 px-3 py-2 overflow-y-auto overflow-x-hidden box-border rounded-md border border-black bg-background focus:outline-none focus:ring-0 focus:border-black dark:border-white dark:focus:border-white"
+                                            disabled={isSaving}
+                                            rows={3}
+                                        />
+                                    </div>
+                                ) : (
+                                    <p className="text-sm text-foreground whitespace-pre-wrap">{ann.content}</p>
+                                )}
+                            </div>
+                        ))}
+                        {moreCount > 0 && (
+                            <p className="text-xs text-muted-foreground">
+                                +{moreCount} more {moreCount === 1 ? "reply" : "replies"} — click to show
+                            </p>
+                        )}
+                    </div>
+
+                    {/* Reply composer — only after user clicked this highlight or the card */}
+                    {canWrite && isActive && (
+                        <div ref={replySectionRef} className="px-4 pb-4 pt-0">
+                            {isReplyOpen ? (
+                                /* Expanded: full textarea, no avatar */
+                                <div className="flex flex-col gap-2">
+                                    <textarea
+                                        ref={replyTextareaRef}
+                                        autoFocus
+                                        value={replyContent}
+                                        onChange={(e) => {
+                                            setReplyContent(e.target.value);
+                                            autoResizeContained(e.target);
+                                        }}
+                                        onKeyDown={handleReplyKeyDown}
+                                        placeholder="Write a reply…"
+                                        className="text-sm text-foreground placeholder:text-muted-foreground resize-none w-full min-h-[4rem] max-h-48 px-3 py-2 overflow-y-auto overflow-x-hidden box-border rounded-md border border-black bg-background focus:outline-none focus:ring-0 focus:border-black dark:border-white dark:focus:border-white"
+                                        disabled={isSaving}
+                                        rows={3}
+                                    />
+                                    <div className="flex items-center justify-end gap-2">
+                                        <Button
+                                            variant="ghost"
+                                            size="sm"
+                                            className="h-7 px-2 text-xs text-muted-foreground"
+                                            onClick={(e) => {
+                                                e.stopPropagation();
+                                                setReplyContent("");
+                                                setIsReplyOpen(false);
+                                            }}
+                                            onMouseDown={(e) => e.stopPropagation()}
+                                            disabled={isSaving}
+                                        >
+                                            Cancel
+                                        </Button>
+                                        <Button
+                                            size="sm"
+                                            className="h-7 px-3 text-xs"
+                                            onClick={(e) => { e.stopPropagation(); handleSaveReply(); }}
+                                            onMouseDown={(e) => e.stopPropagation()}
+                                            disabled={!replyContent.trim() || isSaving}
+                                        >
+                                            Reply
+                                        </Button>
+                                    </div>
+                                </div>
+                            ) : (
+                                /* Collapsed pill */
+                                <button
+                                    type="button"
+                                    className="w-full text-left text-sm text-muted-foreground rounded-full border border-border px-3 py-1.5 hover:bg-muted/50 transition-colors cursor-text"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onCardFocus?.();
+                                        setIsReplyOpen(true);
+                                    }}
+                                >
+                                    Reply…
+                                </button>
+                            )}
+                        </div>
+                    )}
+                </>
             )}
         </div>
     );

--- a/client/src/components/InlineAnnotationCard.tsx
+++ b/client/src/components/InlineAnnotationCard.tsx
@@ -4,7 +4,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import { BasicUser } from "@/lib/auth";
 import { PaperHighlightAnnotation } from "@/lib/schema";
-import { cn, getAlphaHashToBackgroundColor, getInitials, formatDate } from "@/lib/utils";
+import { cn, formatAnnotationDate, getAlphaHashToBackgroundColor, getInitials } from "@/lib/utils";
 import { Pencil, Trash2, X } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 
@@ -262,7 +262,12 @@ export function InlineAnnotationCard({
         <div
             ref={cardRef}
             data-inline-annotation-card=""
-            className={`absolute z-40 w-[280px] border border-border rounded-xl shadow-lg flex flex-col transition-[top,left,background-color,border-color] duration-200 ease-out motion-reduce:transition-none overflow-hidden ${isActive ? "bg-background" : "bg-[#ebebeb] dark:bg-zinc-800"}`}
+            className={cn(
+                "absolute z-40 w-[280px] rounded-xl shadow-lg flex flex-col transition-[top,left,background-color,border-color] duration-200 ease-out motion-reduce:transition-none overflow-hidden",
+                isActive
+                    ? "border border-border bg-background"
+                    : "border-0 bg-[#F9FAFD] dark:bg-zinc-800"
+            )}
             style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
             onClick={(e) => e.stopPropagation()}
             onMouseDown={(e) => {
@@ -302,20 +307,49 @@ export function InlineAnnotationCard({
                         )}
                     </div>
                     {canWrite ? (
-                        <textarea
-                            ref={newTextareaRef}
-                            value={newContent}
-                            onChange={(e) => {
-                                setNewContent(e.target.value);
-                                autoResizeContained(e.target);
-                            }}
-                            onKeyDown={handleNewKeyDown}
-                            placeholder="Write your notes here and press Enter to save"
-                            aria-label="New annotation"
-                            className="text-sm text-foreground placeholder:text-muted-foreground resize-none w-full min-h-[4rem] max-h-48 px-3 py-2 overflow-y-auto overflow-x-hidden box-border rounded-md border border-black bg-background focus:outline-none focus:ring-0 focus:border-black dark:border-white dark:focus:border-white"
-                            disabled={isSaving}
-                            rows={3}
-                        />
+                        <div className="flex flex-col gap-2">
+                            <textarea
+                                ref={newTextareaRef}
+                                value={newContent}
+                                onChange={(e) => {
+                                    setNewContent(e.target.value);
+                                    autoResizeContained(e.target);
+                                }}
+                                onKeyDown={handleNewKeyDown}
+                                placeholder="Write your notes here…"
+                                aria-label="New annotation"
+                                className="text-sm text-foreground placeholder:text-muted-foreground resize-none w-full min-h-[4rem] max-h-48 px-3 py-2 overflow-y-auto overflow-x-hidden box-border rounded-md border border-black bg-background focus:outline-none focus:ring-0 focus:border-black dark:border-white dark:focus:border-white"
+                                disabled={isSaving}
+                                rows={3}
+                            />
+                            <div className="flex items-center justify-end gap-2">
+                                <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-7 px-2 text-xs text-muted-foreground"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        onClose();
+                                    }}
+                                    onMouseDown={(e) => e.stopPropagation()}
+                                    disabled={isSaving}
+                                >
+                                    Cancel
+                                </Button>
+                                <Button
+                                    size="sm"
+                                    className="h-7 px-3 text-xs"
+                                    onClick={(e) => {
+                                        e.stopPropagation();
+                                        handleSaveNew();
+                                    }}
+                                    onMouseDown={(e) => e.stopPropagation()}
+                                    disabled={!newContent.trim() || isSaving}
+                                >
+                                    Save
+                                </Button>
+                            </div>
+                        </div>
                     ) : (
                         <p className="text-sm text-muted-foreground italic">No annotation yet.</p>
                     )}
@@ -343,7 +377,7 @@ export function InlineAnnotationCard({
                                     </Avatar>
                                     <div className="flex flex-col leading-tight flex-1 min-w-0">
                                         <span className="text-xs font-medium">{displayName}</span>
-                                        <span className="text-[11px] text-muted-foreground">{formatDate(ann.created_at)}</span>
+                                        <span className="text-[11px] text-muted-foreground">{formatAnnotationDate(ann.created_at)}</span>
                                     </div>
                                     {ann.role === "user" && isActive && (
                                         <div className="flex items-center gap-0.5 flex-shrink-0">
@@ -385,7 +419,7 @@ export function InlineAnnotationCard({
                                     )}
                                 </div>
                                 {editingId === ann.id ? (
-                                    <div ref={editBlockRef} className="w-full min-w-0">
+                                    <div ref={editBlockRef} className="w-full min-w-0 flex flex-col gap-2">
                                         <textarea
                                             ref={editTextareaRef}
                                             autoFocus
@@ -400,6 +434,33 @@ export function InlineAnnotationCard({
                                             disabled={isSaving}
                                             rows={3}
                                         />
+                                        <div className="flex items-center justify-end gap-2">
+                                            <Button
+                                                variant="ghost"
+                                                size="sm"
+                                                className="h-7 px-2 text-xs text-muted-foreground"
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    setEditingId(null);
+                                                }}
+                                                onMouseDown={(e) => e.stopPropagation()}
+                                                disabled={isSaving}
+                                            >
+                                                Cancel
+                                            </Button>
+                                            <Button
+                                                size="sm"
+                                                className="h-7 px-3 text-xs"
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    handleSaveEdit(ann.id);
+                                                }}
+                                                onMouseDown={(e) => e.stopPropagation()}
+                                                disabled={!editContent.trim() || isSaving}
+                                            >
+                                                Save
+                                            </Button>
+                                        </div>
                                     </div>
                                 ) : (
                                     <p className="text-sm text-foreground whitespace-pre-wrap">{ann.content}</p>

--- a/client/src/components/InlineAnnotationCard.tsx
+++ b/client/src/components/InlineAnnotationCard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { BasicUser } from "@/lib/auth";
+import { PaperHighlightAnnotation } from "@/lib/schema";
+import { getAlphaHashToBackgroundColor, getInitials } from "@/lib/utils";
+import { X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+interface InlineAnnotationCardProps {
+    highlightId: string;
+    topPosition: number;
+    leftPosition: number;
+    initialContent?: string;
+    isActive?: boolean;
+    user: BasicUser | null;
+    addAnnotation: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
+    onClose: () => void;
+}
+
+export function InlineAnnotationCard({
+    highlightId,
+    topPosition,
+    leftPosition,
+    initialContent,
+    isActive = false,
+    user,
+    addAnnotation,
+    onClose,
+}: InlineAnnotationCardProps) {
+    const [content, setContent] = useState(initialContent ?? "");
+    const [isSaving, setIsSaving] = useState(false);
+    const [isEditing, setIsEditing] = useState(!initialContent);
+    const cardRef = useRef<HTMLDivElement>(null);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    const now = new Date();
+    const timeStr = now.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+    const timestamp = `${timeStr} Today`;
+
+    const handleSave = async () => {
+        if (!content.trim() || isSaving) return;
+        setIsSaving(true);
+        try {
+            await addAnnotation(highlightId, content.trim());
+            setIsEditing(false);
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+            e.preventDefault();
+            handleSave();
+        } else if (e.key === "Escape") {
+            onClose();
+        }
+    };
+
+    // Focus textarea when entering edit mode
+    useEffect(() => {
+        if (isEditing && textareaRef.current) {
+            textareaRef.current.focus();
+            // Move cursor to end
+            const len = textareaRef.current.value.length;
+            textareaRef.current.setSelectionRange(len, len);
+        }
+    }, [isEditing]);
+
+    // Outside click: close only if nothing has been typed; otherwise collapse to read mode
+    useEffect(() => {
+        const handleOutsideClick = (e: MouseEvent) => {
+            if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+                if (!content.trim()) {
+                    onClose();
+                } else if (isEditing) {
+                    setIsEditing(false);
+                }
+            }
+        };
+        const timerId = setTimeout(() => {
+            document.addEventListener("mousedown", handleOutsideClick);
+        }, 100);
+        return () => {
+            clearTimeout(timerId);
+            document.removeEventListener("mousedown", handleOutsideClick);
+        };
+    }, [onClose, content, isEditing]);
+
+    const displayName = user?.name || "Anonymous";
+    const avatarBg = user?.name ? getAlphaHashToBackgroundColor(user.name) : "bg-muted";
+
+    return (
+        <div
+            ref={cardRef}
+            className={`absolute z-40 w-[280px] border border-border rounded-xl shadow-lg p-4 flex flex-col gap-3 transition-colors duration-200 ${isActive ? "bg-background" : "bg-[#ebebeb] dark:bg-zinc-800"} ${!isEditing && content ? "cursor-pointer" : ""}`}
+            style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
+            onClick={(e) => {
+                e.stopPropagation();
+                if (!isEditing && content) setIsEditing(true);
+            }}
+            onMouseDown={(e) => e.stopPropagation()}
+        >
+            {/* User info */}
+            <div className="flex items-center gap-3">
+                <Avatar className="h-9 w-9 flex-shrink-0">
+                    {user?.picture && <AvatarImage src={user.picture} alt={displayName} />}
+                    <AvatarFallback
+                        className="text-xs text-white font-medium"
+                        style={{ backgroundColor: avatarBg }}
+                    >
+                        {getInitials(displayName)}
+                    </AvatarFallback>
+                </Avatar>
+                <div className="flex flex-col leading-tight flex-1">
+                    <span className="text-sm font-medium">{displayName}</span>
+                    <span className="text-xs text-muted-foreground">{timestamp}</span>
+                </div>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 text-muted-foreground hover:text-foreground flex-shrink-0"
+                    onClick={(e) => { e.stopPropagation(); onClose(); }}
+                    onMouseDown={(e) => e.stopPropagation()}
+                >
+                    <X size={14} />
+                </Button>
+            </div>
+
+            {/* Annotation — editable textarea in edit mode, plain text in read mode */}
+            {isEditing ? (
+                <textarea
+                    ref={textareaRef}
+                    value={content}
+                    onChange={(e) => setContent(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder="Write your notes here and press Enter to save"
+                    className="text-sm text-foreground placeholder:text-muted-foreground resize-none bg-transparent border-none outline-none w-full min-h-[72px] p-0 focus:outline-none"
+                    rows={3}
+                    disabled={isSaving}
+                />
+            ) : (
+                <p className="text-sm text-foreground whitespace-pre-wrap">{content}</p>
+            )}
+        </div>
+    );
+}

--- a/client/src/components/InlineAnnotationCard.tsx
+++ b/client/src/components/InlineAnnotationCard.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { BasicUser } from "@/lib/auth";
 import { PaperHighlightAnnotation } from "@/lib/schema";
 import { getAlphaHashToBackgroundColor, getInitials } from "@/lib/utils";
-import { X } from "lucide-react";
+import { Pencil, Trash2, X } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 interface InlineAnnotationCardProps {
@@ -13,10 +13,15 @@ interface InlineAnnotationCardProps {
     topPosition: number;
     leftPosition: number;
     initialContent?: string;
+    annotationId?: string;
     isActive?: boolean;
     user: BasicUser | null;
     addAnnotation: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
+    updateAnnotation?: (annotationId: string, content: string) => Promise<unknown> | void;
+    onAnnotationSaved?: (annotationId: string) => void;
+    onDelete?: () => void;
     onClose: () => void;
+    onHeightChange?: (height: number) => void;
 }
 
 export function InlineAnnotationCard({
@@ -24,10 +29,15 @@ export function InlineAnnotationCard({
     topPosition,
     leftPosition,
     initialContent,
+    annotationId,
     isActive = false,
     user,
     addAnnotation,
+    updateAnnotation,
+    onAnnotationSaved,
+    onDelete,
     onClose,
+    onHeightChange,
 }: InlineAnnotationCardProps) {
     const [content, setContent] = useState(initialContent ?? "");
     const [isSaving, setIsSaving] = useState(false);
@@ -43,7 +53,12 @@ export function InlineAnnotationCard({
         if (!content.trim() || isSaving) return;
         setIsSaving(true);
         try {
-            await addAnnotation(highlightId, content.trim());
+            if (annotationId && updateAnnotation) {
+                await updateAnnotation(annotationId, content.trim());
+            } else {
+                const result = await addAnnotation(highlightId, content.trim());
+                onAnnotationSaved?.(result.id);
+            }
             setIsEditing(false);
         } finally {
             setIsSaving(false);
@@ -59,15 +74,28 @@ export function InlineAnnotationCard({
         }
     };
 
-    // Focus textarea when entering edit mode
+    // Focus textarea and auto-size it to full content height when entering edit mode
     useEffect(() => {
         if (isEditing && textareaRef.current) {
-            textareaRef.current.focus();
-            // Move cursor to end
-            const len = textareaRef.current.value.length;
-            textareaRef.current.setSelectionRange(len, len);
+            const el = textareaRef.current;
+            el.style.height = 'auto';
+            el.style.height = `${el.scrollHeight}px`;
+            el.focus();
+            const len = el.value.length;
+            el.setSelectionRange(len, len);
         }
     }, [isEditing]);
+
+    // Report actual card height to parent whenever it changes (e.g. edit mode toggle, long text)
+    useEffect(() => {
+        const el = cardRef.current;
+        if (!el || !onHeightChange) return;
+        const ro = new ResizeObserver(() => {
+            onHeightChange(el.offsetHeight);
+        });
+        ro.observe(el);
+        return () => ro.disconnect();
+    }, [onHeightChange]);
 
     // Outside click: close only if nothing has been typed; otherwise collapse to read mode
     useEffect(() => {
@@ -95,15 +123,12 @@ export function InlineAnnotationCard({
     return (
         <div
             ref={cardRef}
-            className={`absolute z-40 w-[280px] border border-border rounded-xl shadow-lg p-4 flex flex-col gap-3 transition-colors duration-200 ${isActive ? "bg-background" : "bg-[#ebebeb] dark:bg-zinc-800"} ${!isEditing && content ? "cursor-pointer" : ""}`}
+            className={`absolute z-40 w-[280px] border border-border rounded-xl shadow-lg p-4 flex flex-col gap-3 transition-colors duration-200 ${isActive ? "bg-background" : "bg-[#ebebeb] dark:bg-zinc-800"}`}
             style={{ left: `${leftPosition}px`, top: `${topPosition}px` }}
-            onClick={(e) => {
-                e.stopPropagation();
-                if (!isEditing && content) setIsEditing(true);
-            }}
+            onClick={(e) => e.stopPropagation()}
             onMouseDown={(e) => e.stopPropagation()}
         >
-            {/* User info */}
+            {/* Header: avatar + name/timestamp + action icons */}
             <div className="flex items-center gap-3">
                 <Avatar className="h-9 w-9 flex-shrink-0">
                     {user?.picture && <AvatarImage src={user.picture} alt={displayName} />}
@@ -114,19 +139,50 @@ export function InlineAnnotationCard({
                         {getInitials(displayName)}
                     </AvatarFallback>
                 </Avatar>
-                <div className="flex flex-col leading-tight flex-1">
+                <div className="flex flex-col leading-tight flex-1 min-w-0">
                     <span className="text-sm font-medium">{displayName}</span>
                     <span className="text-xs text-muted-foreground">{timestamp}</span>
                 </div>
-                <Button
-                    variant="ghost"
-                    size="icon"
-                    className="h-6 w-6 text-muted-foreground hover:text-foreground flex-shrink-0"
-                    onClick={(e) => { e.stopPropagation(); onClose(); }}
-                    onMouseDown={(e) => e.stopPropagation()}
-                >
-                    <X size={14} />
-                </Button>
+
+                {/* Action icons */}
+                <div className="flex items-center gap-0.5 flex-shrink-0">
+                    {!isEditing && (
+                        <>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                                onClick={(e) => { e.stopPropagation(); setIsEditing(true); }}
+                                onMouseDown={(e) => e.stopPropagation()}
+                                title="Edit"
+                            >
+                                <Pencil size={13} />
+                            </Button>
+                            {annotationId && (
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                                    onClick={(e) => { e.stopPropagation(); onDelete?.(); }}
+                                    onMouseDown={(e) => e.stopPropagation()}
+                                    title="Delete"
+                                >
+                                    <Trash2 size={13} />
+                                </Button>
+                            )}
+                        </>
+                    )}
+                    <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                        onClick={(e) => { e.stopPropagation(); onClose(); }}
+                        onMouseDown={(e) => e.stopPropagation()}
+                        title="Close"
+                    >
+                        <X size={14} />
+                    </Button>
+                </div>
             </div>
 
             {/* Annotation — editable textarea in edit mode, plain text in read mode */}
@@ -134,11 +190,14 @@ export function InlineAnnotationCard({
                 <textarea
                     ref={textareaRef}
                     value={content}
-                    onChange={(e) => setContent(e.target.value)}
+                    onChange={(e) => {
+                        setContent(e.target.value);
+                        e.target.style.height = 'auto';
+                        e.target.style.height = `${e.target.scrollHeight}px`;
+                    }}
                     onKeyDown={handleKeyDown}
                     placeholder="Write your notes here and press Enter to save"
-                    className="text-sm text-foreground placeholder:text-muted-foreground resize-none bg-transparent border-none outline-none w-full min-h-[72px] p-0 focus:outline-none"
-                    rows={3}
+                    className="text-sm text-foreground placeholder:text-muted-foreground resize-none bg-transparent border-none outline-none w-full min-h-0 p-0 focus:outline-none overflow-hidden"
                     disabled={isSaving}
                 />
             ) : (

--- a/client/src/components/InlineAnnotationMenu.tsx
+++ b/client/src/components/InlineAnnotationMenu.tsx
@@ -20,6 +20,7 @@ interface InlineAnnotationMenuProps {
     addHighlight: (selectedText: string, doAnnotate?: boolean) => void;
     removeHighlight: (highlight: PaperHighlight) => void;
     setUserMessageReferences: React.Dispatch<React.SetStateAction<string[]>>;
+    onAnnotate: (y: number) => void;
 }
 
 // Estimated height of the menu (5-6 buttons at ~36px each + padding)
@@ -39,6 +40,7 @@ export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
         addHighlight,
         removeHighlight,
         setUserMessageReferences,
+        onAnnotate,
     } = props;
 
     const menuRef = useRef<HTMLDivElement>(null);
@@ -99,6 +101,7 @@ export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
                 setTooltipPosition(null);
                 setIsAnnotating(false);
             } else if (e.key === "e" && (e.ctrlKey || e.metaKey)) {
+                if (tooltipPosition) onAnnotate(tooltipPosition.y);
                 setIsAnnotating(true);
                 setTooltipPosition(null);
                 setSelectedText("");
@@ -179,6 +182,7 @@ export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
                         onMouseDown={(e) => e.preventDefault()}
                         onClick={(e) => {
                             e.stopPropagation();
+                            if (tooltipPosition) onAnnotate(tooltipPosition.y);
                             setIsAnnotating(true);
                             setTooltipPosition(null);
                             setSelectedText("");

--- a/client/src/components/InlineAnnotationMenu.tsx
+++ b/client/src/components/InlineAnnotationMenu.tsx
@@ -80,6 +80,31 @@ export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
         const top = spaceBelow >= MENU_HEIGHT
             ? tooltipPosition.y + MENU_OFFSET
             : tooltipPosition.y - MENU_HEIGHT - MENU_OFFSET;
+        // #region agent log
+        fetch("http://127.0.0.1:7848/ingest/1ffc24a3-d0c6-4802-9576-899d9a9fb32b", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+                "X-Debug-Session-Id": "434c20",
+            },
+            body: JSON.stringify({
+                sessionId: "434c20",
+                hypothesisId: "H3",
+                location: "InlineAnnotationMenu.tsx:menuPosition",
+                message: "computed menu top",
+                data: {
+                    anchorY: tooltipPosition.y,
+                    innerHeight: window.innerHeight,
+                    spaceBelow,
+                    branchBelow: spaceBelow >= MENU_HEIGHT,
+                    top,
+                    left,
+                },
+                timestamp: Date.now(),
+                runId: "pre-fix",
+            }),
+        }).catch(() => {});
+        // #endregion
         setMenuPosition({ left, top });
     }, [tooltipPosition]);
 

--- a/client/src/components/InlineAnnotationMenu.tsx
+++ b/client/src/components/InlineAnnotationMenu.tsx
@@ -146,6 +146,7 @@ export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
     return (
         <div
             ref={menuRef}
+            data-inline-annotation-menu=""
             className="fixed z-30 bg-background shadow-md rounded-lg border border-border"
             style={{ left: `${menuPosition.left}px`, top: `${menuPosition.top}px` }}
             onClick={(e) => e.stopPropagation()}

--- a/client/src/components/InlineAnnotationMenu.tsx
+++ b/client/src/components/InlineAnnotationMenu.tsx
@@ -4,8 +4,7 @@ import {
 
 import { useEffect, useState, useRef } from "react";
 import { Button } from "./ui/button";
-import { CommandShortcut, localizeCommandToOS } from "./ui/command";
-import { Bookmark, Copy, Highlighter, MessageCircle, Minus, X } from "lucide-react";
+import { Bookmark, Copy, Highlighter, MessageCircle, Minus } from "lucide-react";
 
 interface InlineAnnotationMenuProps {
     selectedText: string;
@@ -23,10 +22,31 @@ interface InlineAnnotationMenuProps {
     onAnnotate: (y: number) => void;
 }
 
-// Estimated height of the menu (5-6 buttons at ~36px each + padding)
-const MENU_HEIGHT = 280;
-const MENU_WIDTH = 220;
-const MENU_OFFSET = 20;
+// Compact horizontal card — always rendered below the anchor
+const MENU_HEIGHT = 40;
+const MENU_WIDTH = 300;
+const MENU_OFFSET = 6;
+
+interface ActionButtonProps {
+    icon: React.ReactNode;
+    label: string;
+    onClick: (e: React.MouseEvent) => void;
+    className?: string;
+}
+
+function ActionButton({ icon, label, onClick, className = "" }: ActionButtonProps) {
+    return (
+        <Button
+            variant="ghost"
+            className={`flex items-center gap-1 h-6 px-1.5 text-[11px] font-normal ${className}`}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={onClick}
+        >
+            {icon}
+            {label}
+        </Button>
+    );
+}
 
 export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
     const {
@@ -46,60 +66,40 @@ export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
     const menuRef = useRef<HTMLDivElement>(null);
     const [menuPosition, setMenuPosition] = useState<{ left: number; top: number } | null>(null);
 
-    // Calculate optimal position when tooltip position changes
+    // Always place below the anchor, clamped to viewport edges
     useEffect(() => {
         if (!tooltipPosition) {
             setMenuPosition(null);
             return;
         }
-
-        // Calculate horizontal position (keep existing logic)
-        const left = Math.min(tooltipPosition.x, window.innerWidth - MENU_WIDTH);
-
-        // Calculate vertical position - check if menu fits below cursor
+        const left = Math.min(
+            Math.max(0, tooltipPosition.x),
+            window.innerWidth - MENU_WIDTH
+        );
         const spaceBelow = window.innerHeight - tooltipPosition.y - MENU_OFFSET;
-        const spaceAbove = tooltipPosition.y - MENU_OFFSET;
-
-        let top: number;
-        if (spaceBelow >= MENU_HEIGHT) {
-            // Enough space below - render below cursor
-            top = tooltipPosition.y + MENU_OFFSET;
-        } else if (spaceAbove >= MENU_HEIGHT) {
-            // Not enough space below, but enough above - render above cursor
-            top = tooltipPosition.y - MENU_HEIGHT - MENU_OFFSET;
-        } else {
-            // Not enough space either way - render where there's more space
-            if (spaceBelow >= spaceAbove) {
-                top = tooltipPosition.y + MENU_OFFSET;
-            } else {
-                top = Math.max(10, tooltipPosition.y - MENU_HEIGHT - MENU_OFFSET);
-            }
-        }
-
+        const top = spaceBelow >= MENU_HEIGHT
+            ? tooltipPosition.y + MENU_OFFSET
+            : tooltipPosition.y - MENU_HEIGHT - MENU_OFFSET;
         setMenuPosition({ left, top });
     }, [tooltipPosition]);
 
+    // Keyboard shortcuts
     useEffect(() => {
-        const handleMouseDown = (e: KeyboardEvent) => {
+        const handleKeyDown = (e: KeyboardEvent) => {
             if (e.key === "Escape") {
-                setSelectedText("");
-                setTooltipPosition(null);
-                setIsAnnotating(false);
+                close();
             } else if (e.key === "c" && (e.ctrlKey || e.metaKey)) {
                 navigator.clipboard.writeText(selectedText);
             } else if (e.key === "a" && (e.ctrlKey || e.metaKey)) {
-                setUserMessageReferences((prev: string[]) => {
-                    const newReferences = [...prev, selectedText];
-                    return Array.from(new Set(newReferences)); // Remove duplicates
-                });
+                setUserMessageReferences((prev: string[]) =>
+                    Array.from(new Set([...prev, selectedText]))
+                );
             } else if (e.key === "h" && (e.ctrlKey || e.metaKey)) {
                 addHighlight(selectedText);
                 e.stopPropagation();
             } else if (e.key === "d" && (e.ctrlKey || e.metaKey) && isHighlightInteraction && activeHighlight) {
                 removeHighlight(activeHighlight);
-                setSelectedText("");
-                setTooltipPosition(null);
-                setIsAnnotating(false);
+                close();
             } else if (e.key === "e" && (e.ctrlKey || e.metaKey)) {
                 if (tooltipPosition) onAnnotate(tooltipPosition.y);
                 setIsAnnotating(true);
@@ -108,166 +108,115 @@ export default function InlineAnnotationMenu(props: InlineAnnotationMenuProps) {
             } else {
                 return;
             }
-
             e.preventDefault();
             e.stopPropagation();
-        }
+        };
 
-        window.addEventListener("keydown", handleMouseDown);
-        return () => window.removeEventListener("keydown", handleMouseDown);
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
     }, [selectedText]);
+
+    const close = () => {
+        setSelectedText("");
+        setTooltipPosition(null);
+        setIsAnnotating(false);
+    };
+
+    // Dismiss on outside click
+    useEffect(() => {
+        const handleOutsideClick = (e: MouseEvent) => {
+            const target = e.target as HTMLElement;
+            // Let handleHighlightClick handle highlight clicks — don't close here
+            if (target.closest?.('.TextHighlight__parts, .TextHighlight__part')) return;
+            if (menuRef.current && !menuRef.current.contains(target)) {
+                close();
+            }
+        };
+        const timerId = setTimeout(() => {
+            document.addEventListener("mousedown", handleOutsideClick);
+        }, 100);
+        return () => {
+            clearTimeout(timerId);
+            document.removeEventListener("mousedown", handleOutsideClick);
+        };
+    }, [tooltipPosition]);
 
     if (!tooltipPosition || !menuPosition) return null;
 
     return (
         <div
             ref={menuRef}
-            className="fixed z-30 bg-background shadow-lg rounded-lg p-3 border border-border w-[200px]"
-            style={{
-                left: `${menuPosition.left}px`,
-                top: `${menuPosition.top}px`,
-            }}
+            className="fixed z-30 bg-background shadow-md rounded-lg border border-border"
+            style={{ left: `${menuPosition.left}px`, top: `${menuPosition.top}px` }}
             onClick={(e) => e.stopPropagation()}
             onMouseDown={(e) => e.stopPropagation()}
         >
-            <div className="flex flex-col gap-1.5">
-                {/* Copy Button */}
-                <Button
-                    variant="ghost"
-                    className="w-full flex items-center justify-between text-sm font-normal h-9 px-2"
-                    onClick={() => {
-                        navigator.clipboard.writeText(selectedText);
-                        setSelectedText("");
-                        setTooltipPosition(null);
-                        setIsAnnotating(false);
-                    }}
-                >
-                    <div className="flex items-center gap-2">
-                        <Copy size={14} />
-                        Copy
-                    </div>
-                    <CommandShortcut className="text-muted-foreground">
-                        {localizeCommandToOS('C')}
-                    </CommandShortcut>
-                </Button>
-
-                {/* Highlight Button */}
-                {
-                    !isHighlightInteraction && (
-                        <Button
-                            variant="ghost"
-                            className="w-full flex items-center justify-between text-sm font-normal h-9 px-2"
-                            onMouseDown={(e) => e.preventDefault()}
-                            onClick={(e) => {
-                                e.stopPropagation();
-                                addHighlight(selectedText, false);
-                            }}
-                        >
-                            <div className="flex items-center gap-2">
-                                <Bookmark size={14} />
-                                Save
-                            </div>
-                            <CommandShortcut className="text-muted-foreground">
-                                {localizeCommandToOS('H')}
-                            </CommandShortcut>
-                        </Button>
-                    )
-                }
-
-                {/* Annotate Button */}
-                {
-                    <Button
-                        variant="ghost"
-                        className="w-full flex items-center justify-between text-sm font-normal h-9 px-2"
-                        onMouseDown={(e) => e.preventDefault()}
+            <div className="flex items-center gap-0.5 p-1">
+                {/* Save — hidden when interacting with an existing highlight */}
+                {!isHighlightInteraction && (
+                    <ActionButton
+                        icon={<Bookmark size={11} />}
+                        label="Save"
                         onClick={(e) => {
                             e.stopPropagation();
-                            if (tooltipPosition) onAnnotate(tooltipPosition.y);
-                            setIsAnnotating(true);
-                            setTooltipPosition(null);
-                            setSelectedText("");
-                            if (!isHighlightInteraction) {
-                                addHighlight(selectedText, true);
-                            }
+                            addHighlight(selectedText, false);
                         }}
-                    >
-                        <div className="flex items-center gap-2">
-                            <Highlighter size={14} />
-                            Annotate
-                        </div>
-                        <CommandShortcut className="text-muted-foreground">
-                            {localizeCommandToOS('E')}
-                        </CommandShortcut>
-                    </Button>
-                }
-
-                {/* Add to Chat Button */}
-                <Button
-                    variant="ghost"
-                    className="w-full flex items-center justify-between text-sm font-normal h-9 px-2"
-                    onMouseDown={(e) => e.preventDefault()}
-                    onClick={(e) => {
-                        setUserMessageReferences(prev => Array.from(new Set([...prev, selectedText])));
-                        setSelectedText("");
-                        setTooltipPosition(null);
-                        setIsAnnotating(false);
-                        e.stopPropagation();
-                    }}
-                >
-                    <div className="flex items-center gap-2">
-                        <MessageCircle size={14} />
-                        Ask
-                    </div>
-                    <CommandShortcut className="text-muted-foreground">
-                        {localizeCommandToOS('A')}
-                    </CommandShortcut>
-                </Button>
-
-
-                {/* Remove Highlight Button - Only show when interacting with highlight */}
-                {isHighlightInteraction && activeHighlight && (
-                    <Button
-                        variant="ghost"
-                        className="w-full flex items-center justify-between text-sm font-normal h-9 px-2 text-destructive"
-                        onMouseDown={(e) => e.preventDefault()}
-                        onClick={(e) => {
-                            e.stopPropagation();
-                            if (activeHighlight) {
-                                removeHighlight(activeHighlight);
-                                setSelectedText("");
-                                setTooltipPosition(null);
-                                setIsAnnotating(false);
-                            }
-                        }}
-                    >
-                        <div className="flex items-center gap-2">
-                            <Minus size={14} />
-                            Delete
-                        </div>
-                        <CommandShortcut className="text-muted-foreground">
-                            {localizeCommandToOS('D')}
-                        </CommandShortcut>
-                    </Button>
+                    />
                 )}
 
-                {/* Close Button */}
-                <Button
-                    variant="ghost"
-                    className="w-full flex items-center justify-between text-sm font-normal h-9 px-2"
-                    onClick={() => {
-                        setSelectedText("");
+                {/* Annotate */}
+                <ActionButton
+                    icon={<Highlighter size={11} />}
+                    label="Annotate"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        if (tooltipPosition) onAnnotate(tooltipPosition.y);
+                        setIsAnnotating(true);
                         setTooltipPosition(null);
-                        setIsAnnotating(false);
+                        setSelectedText("");
+                        if (!isHighlightInteraction) {
+                            addHighlight(selectedText, true);
+                        }
                     }}
-                >
-                    <div className="flex items-center gap-2">
-                        <X size={14} />
-                        Close
-                    </div>
-                    <CommandShortcut className="text-muted-foreground">
-                        Esc
-                    </CommandShortcut>
-                </Button>
+                />
+
+                {/* Ask */}
+                <ActionButton
+                    icon={<MessageCircle size={11} />}
+                    label="Ask"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        setUserMessageReferences(prev =>
+                            Array.from(new Set([...prev, selectedText]))
+                        );
+                        close();
+                    }}
+                />
+
+                {/* Copy */}
+                <ActionButton
+                    icon={<Copy size={11} />}
+                    label="Copy"
+                    onClick={() => {
+                        navigator.clipboard.writeText(selectedText);
+                        close();
+                    }}
+                />
+
+                {/* Delete — only when interacting with an existing highlight */}
+                {isHighlightInteraction && activeHighlight && (
+                    <ActionButton
+                        icon={<Minus size={11} />}
+                        label="Delete"
+                        className="text-destructive hover:text-destructive"
+                        onClick={(e) => {
+                            e.stopPropagation();
+                            removeHighlight(activeHighlight);
+                            close();
+                        }}
+                    />
+                )}
+
             </div>
         </div>
     );

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -5,6 +5,7 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { CitePaperButton } from '@/components/CitePaperButton';
 import { LucideIcon } from 'lucide-react';
 
 interface PaperSidebarProps {
@@ -42,6 +43,16 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                         </TooltipContent>
                     </Tooltip>
                 ))}
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <div>
+                            <CitePaperButton iconOnly />
+                        </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="left" sideOffset={8}>
+                        Cite
+                    </TooltipContent>
+                </Tooltip>
             </div>
         </TooltipProvider>
     );

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { Button } from '@/components/ui/button';
 import {
     Tooltip,
@@ -6,7 +7,6 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { CitePaperButton } from '@/components/CitePaperButton';
-import { LucideIcon } from 'lucide-react';
 
 interface PaperSidebarProps {
     rightSideFunction: string;
@@ -14,34 +14,47 @@ interface PaperSidebarProps {
     PaperToolset: {
         nav: {
             name: string;
-            icon: LucideIcon;
+            icon: React.ComponentType<{ className?: string }>;
         }[];
     };
 }
 
+function NavButton({ item, rightSideFunction, setRightSideFunction }: {
+    item: { name: string; icon: React.ComponentType<{ className?: string }> };
+    rightSideFunction: string;
+    setRightSideFunction: (value: string) => void;
+}) {
+    return (
+        <Tooltip key={item.name}>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    className={`h-10 w-10 p-0 rounded-lg ${
+                        item.name === rightSideFunction
+                            ? 'bg-blue-500 dark:bg-blue-500 text-blue-100 dark:text-blue-100 hover:bg-blue-600 dark:hover:bg-blue-600'
+                            : 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
+                    }`}
+                    onClick={() => setRightSideFunction(item.name)}
+                >
+                    <item.icon className="h-5 w-5" />
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent side="left" sideOffset={8}>
+                {item.name}
+            </TooltipContent>
+        </Tooltip>
+    );
+}
+
 export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset }: PaperSidebarProps) {
+    const beforeFocus = PaperToolset.nav.filter(item => item.name !== 'Focus');
+    const focusTool = PaperToolset.nav.find(item => item.name === 'Focus');
+
     return (
         <TooltipProvider>
             <div className="absolute right-2 top-14 z-20 flex flex-col gap-1 p-1.5 bg-background/95 backdrop-blur-sm border border-border rounded-xl shadow-md">
-                {PaperToolset.nav.map((item) => (
-                    <Tooltip key={item.name}>
-                        <TooltipTrigger asChild>
-                            <Button
-                                variant="ghost"
-                                className={`h-10 w-10 p-0 rounded-lg ${
-                                    item.name === rightSideFunction
-                                        ? 'bg-blue-500 dark:bg-blue-500 text-blue-100 dark:text-blue-100 hover:bg-blue-600 dark:hover:bg-blue-600'
-                                        : 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
-                                }`}
-                                onClick={() => setRightSideFunction(item.name)}
-                            >
-                                <item.icon className="h-5 w-5" />
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="left" sideOffset={8}>
-                            {item.name}
-                        </TooltipContent>
-                    </Tooltip>
+                {beforeFocus.map((item) => (
+                    <NavButton key={item.name} item={item} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
                 ))}
                 <Tooltip>
                     <TooltipTrigger asChild>
@@ -53,6 +66,9 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                         Cite
                     </TooltipContent>
                 </Tooltip>
+                {focusTool && (
+                    <NavButton item={focusTool} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
+                )}
             </div>
         </TooltipProvider>
     );

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -6,6 +6,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import { Eye, EyeOff } from 'lucide-react';
 import React from 'react';
 
 /** Primary panels where the toolbar sits higher (less gap under the top bar). */
@@ -20,6 +21,9 @@ interface PaperSidebarProps {
             icon: React.ComponentType<{ className?: string }>;
         }[];
     };
+    /** Margin annotation cards visibility (PDF reader); omit to hide the control. */
+    showAnnotationCards?: boolean;
+    onToggleAnnotationCards?: () => void;
 }
 
 function NavButton({ item, rightSideFunction, setRightSideFunction }: {
@@ -49,7 +53,13 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
     );
 }
 
-export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset }: PaperSidebarProps) {
+export function PaperSidebar({
+    rightSideFunction,
+    setRightSideFunction,
+    PaperToolset,
+    showAnnotationCards = true,
+    onToggleAnnotationCards,
+}: PaperSidebarProps) {
     const beforeReadTool = PaperToolset.nav.filter(item => item.name !== 'Read');
     const readTool = PaperToolset.nav.find(item => item.name === 'Read');
 
@@ -68,6 +78,29 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                 ))}
                 {readTool && (
                     <NavButton item={readTool} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
+                )}
+                {onToggleAnnotationCards && (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                className={cn(
+                                    'h-7 w-7 p-0 rounded-md',
+                                    showAnnotationCards
+                                        ? 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
+                                        : 'text-muted-foreground hover:bg-blue-100 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200'
+                                )}
+                                onClick={onToggleAnnotationCards}
+                                aria-label={showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
+                            >
+                                {showAnnotationCards ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="left" sideOffset={8}>
+                            {showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
+                        </TooltipContent>
+                    </Tooltip>
                 )}
             </div>
         </TooltipProvider>

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -18,6 +18,8 @@ interface PaperSidebarProps {
     PaperToolset: {
         nav: {
             name: string;
+            /** Tooltip / display name; falls back to `name` when omitted */
+            label?: string;
             icon: React.ComponentType<{ className?: string }>;
         }[];
     };
@@ -27,10 +29,11 @@ interface PaperSidebarProps {
 }
 
 function NavButton({ item, rightSideFunction, setRightSideFunction }: {
-    item: { name: string; icon: React.ComponentType<{ className?: string }> };
+    item: { name: string; label?: string; icon: React.ComponentType<{ className?: string }> };
     rightSideFunction: string;
     setRightSideFunction: (value: string) => void;
 }) {
+    const tooltipLabel = item.label ?? item.name;
     return (
         <Tooltip key={item.name}>
             <TooltipTrigger asChild>
@@ -42,12 +45,13 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
                             : 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
                     }`}
                     onClick={() => setRightSideFunction(item.name)}
+                    aria-label={tooltipLabel}
                 >
                     <item.icon className="h-5 w-5" />
                 </Button>
             </TooltipTrigger>
             <TooltipContent side="left" sideOffset={8}>
-                {item.name}
+                {tooltipLabel}
             </TooltipContent>
         </Tooltip>
     );
@@ -92,13 +96,15 @@ export function PaperSidebar({
                                         : 'text-muted-foreground hover:bg-blue-100 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200'
                                 )}
                                 onClick={onToggleAnnotationCards}
-                                aria-label={showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
+                                aria-label={
+                                    showAnnotationCards ? 'Hide inline annotations' : 'Show inline annotations'
+                                }
                             >
                                 {showAnnotationCards ? <Eye className="h-5 w-5" /> : <EyeOff className="h-5 w-5" />}
                             </Button>
                         </TooltipTrigger>
                         <TooltipContent side="left" sideOffset={8}>
-                            {showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
+                            {showAnnotationCards ? 'Hide inline annotations' : 'Show inline annotations'}
                         </TooltipContent>
                     </Tooltip>
                 )}

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -7,6 +7,7 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { CitePaperButton } from '@/components/CitePaperButton';
+import { Eye, EyeOff } from 'lucide-react';
 
 interface PaperSidebarProps {
     rightSideFunction: string;
@@ -17,6 +18,8 @@ interface PaperSidebarProps {
             icon: React.ComponentType<{ className?: string }>;
         }[];
     };
+    showAnnotationCards: boolean;
+    onToggleAnnotationCards: () => void;
 }
 
 function NavButton({ item, rightSideFunction, setRightSideFunction }: {
@@ -46,7 +49,7 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
     );
 }
 
-export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset }: PaperSidebarProps) {
+export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset, showAnnotationCards, onToggleAnnotationCards }: PaperSidebarProps) {
     const beforeFocus = PaperToolset.nav.filter(item => item.name !== 'Focus');
     const focusTool = PaperToolset.nav.find(item => item.name === 'Focus');
 
@@ -64,6 +67,28 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                     </TooltipTrigger>
                     <TooltipContent side="left" sideOffset={8}>
                         Cite
+                    </TooltipContent>
+                </Tooltip>
+                {/* Annotation cards visibility toggle */}
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <Button
+                            variant="ghost"
+                            className={`h-10 w-10 p-0 rounded-md ${
+                                showAnnotationCards
+                                    ? 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
+                                    : 'text-muted-foreground hover:bg-muted'
+                            }`}
+                            onClick={onToggleAnnotationCards}
+                        >
+                            {showAnnotationCards
+                                ? <Eye className="h-5 w-5" />
+                                : <EyeOff className="h-5 w-5" />
+                            }
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent side="left" sideOffset={8}>
+                        {showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
                     </TooltipContent>
                 </Tooltip>
                 {focusTool && (

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -1,15 +1,10 @@
-import { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
-    Sidebar,
-    SidebarContent,
-    SidebarGroup,
-    SidebarGroupContent,
-    SidebarGroupLabel,
-    SidebarMenu,
-    SidebarMenuItem,
-    SidebarProvider
-} from "@/components/ui/sidebar";
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { LucideIcon } from 'lucide-react';
 
 interface PaperSidebarProps {
@@ -24,41 +19,30 @@ interface PaperSidebarProps {
 }
 
 export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset }: PaperSidebarProps) {
-    const [isSidebarHovered, setIsSidebarHovered] = useState(false);
-
     return (
-        <div
-            className={`flex flex-col h-[calc(100vh-128px)] md:h-[calc(100vh-64px)] absolute right-0 top-0 bg-background z-20 transition-all duration-300 ease-in-out`}
-            onMouseEnter={() => setIsSidebarHovered(true)}
-            onMouseLeave={() => setIsSidebarHovered(false)}
-        >
-            <SidebarProvider className="items-start h-[calc(100vh-128px)] md:h-[calc(100vh-64px)] min-h-fit">
-                <Sidebar collapsible="none" className="flex transition-all duration-300 ease-in-out" style={{ width: isSidebarHovered ? '180px' : '60px' }}>
-                    <SidebarContent>
-                        <SidebarGroup>
-                            <SidebarGroupLabel className={`transition-opacity duration-300 ${isSidebarHovered ? 'opacity-100' : 'opacity-50'}`}>Tools</SidebarGroupLabel>
-                            <SidebarGroupContent>
-                                <SidebarMenu>
-                                    {PaperToolset.nav.map((item) => (
-                                        <SidebarMenuItem key={item.name}>
-                                            <Button
-                                                variant="ghost"
-                                                className={`h-10 p-2 rounded-lg flex items-center overflow-hidden transition-colors duration-200 ${isSidebarHovered ? 'w-full justify-start' : 'w-fit justify-center'} ${item.name === rightSideFunction ? 'bg-blue-500 dark:bg-blue-500 text-blue-100 dark:text-blue-100' : 'text-secondary-foreground hover:bg-blue-200 dark:hover:bg-blue-800'}`}
-                                                onClick={() => {
-                                                    setRightSideFunction(item.name);
-                                                }}
-                                            >
-                                                <item.icon className={`h-5 w-5 flex-shrink-0 ${isSidebarHovered ? "mr-2" : ""}`} />
-                                                {isSidebarHovered && <span className="ml-2 whitespace-nowrap transition-opacity duration-300 opacity-100">{item.name}</span>}
-                                            </Button>
-                                        </SidebarMenuItem>
-                                    ))}
-                                </SidebarMenu>
-                            </SidebarGroupContent>
-                        </SidebarGroup>
-                    </SidebarContent>
-                </Sidebar>
-            </SidebarProvider>
-        </div>
+        <TooltipProvider>
+            <div className="absolute right-2 top-14 z-20 flex flex-col gap-1 p-1.5 bg-background/95 backdrop-blur-sm border border-border rounded-xl shadow-md">
+                {PaperToolset.nav.map((item) => (
+                    <Tooltip key={item.name}>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                className={`h-10 w-10 p-0 rounded-lg ${
+                                    item.name === rightSideFunction
+                                        ? 'bg-blue-500 dark:bg-blue-500 text-blue-100 dark:text-blue-100 hover:bg-blue-600 dark:hover:bg-blue-600'
+                                        : 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
+                                }`}
+                                onClick={() => setRightSideFunction(item.name)}
+                            >
+                                <item.icon className="h-5 w-5" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="left" sideOffset={8}>
+                            {item.name}
+                        </TooltipContent>
+                    </Tooltip>
+                ))}
+            </div>
+        </TooltipProvider>
     );
 }

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -1,20 +1,11 @@
-import { CitePaperButton } from '@/components/CitePaperButton';
-import { HIGHLIGHT_COLOR_SWATCHES } from '@/components/pdf-viewer/highlightColors';
 import { Button } from '@/components/ui/button';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
-import type { HighlightColor } from '@/lib/schema';
 import { cn } from '@/lib/utils';
-import { Eye, EyeOff } from 'lucide-react';
 import React from 'react';
 
 /** Primary panels where the toolbar sits higher (less gap under the top bar). */
@@ -29,10 +20,6 @@ interface PaperSidebarProps {
             icon: React.ComponentType<{ className?: string }>;
         }[];
     };
-    highlightColor?: HighlightColor;
-    setHighlightColor?: (color: HighlightColor) => void;
-    showAnnotationCards?: boolean;
-    onToggleAnnotationCards?: () => void;
 }
 
 function NavButton({ item, rightSideFunction, setRightSideFunction }: {
@@ -62,21 +49,11 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
     );
 }
 
-export function PaperSidebar({
-    rightSideFunction,
-    setRightSideFunction,
-    PaperToolset,
-    highlightColor,
-    setHighlightColor,
-    showAnnotationCards,
-    onToggleAnnotationCards,
-}: PaperSidebarProps) {
+export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset }: PaperSidebarProps) {
     const beforeReadTool = PaperToolset.nav.filter(item => item.name !== 'Read');
     const readTool = PaperToolset.nav.find(item => item.name === 'Read');
 
     const toolbarTopClass = COMPACT_TOP_OFFSET_TOOLS.has(rightSideFunction) ? 'top-2' : 'top-14';
-    const currentSwatch =
-        HIGHLIGHT_COLOR_SWATCHES.find((c) => c.color === highlightColor) || HIGHLIGHT_COLOR_SWATCHES[2];
 
     return (
         <TooltipProvider>
@@ -89,82 +66,8 @@ export function PaperSidebar({
                 {beforeReadTool.map((item) => (
                     <NavButton key={item.name} item={item} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
                 ))}
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <div>
-                            <CitePaperButton iconOnly />
-                        </div>
-                    </TooltipTrigger>
-                    <TooltipContent side="left" sideOffset={8}>
-                        Cite
-                    </TooltipContent>
-                </Tooltip>
                 {readTool && (
                     <NavButton item={readTool} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
-                )}
-                {onToggleAnnotationCards && showAnnotationCards !== undefined && (
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <Button
-                                type="button"
-                                variant="ghost"
-                                className={cn(
-                                    'h-7 w-7 p-0 rounded-md',
-                                    showAnnotationCards
-                                        ? 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
-                                        : 'text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200'
-                                )}
-                                onClick={onToggleAnnotationCards}
-                                aria-label={showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
-                            >
-                                {showAnnotationCards ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
-                            </Button>
-                        </TooltipTrigger>
-                        <TooltipContent side="left" sideOffset={8}>
-                            {showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
-                        </TooltipContent>
-                    </Tooltip>
-                )}
-                {highlightColor !== undefined && setHighlightColor && (
-                    <DropdownMenu>
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <DropdownMenuTrigger asChild>
-                                    <Button
-                                        type="button"
-                                        variant="ghost"
-                                        className="h-7 w-7 p-0 rounded-full"
-                                        aria-label="Highlight color"
-                                    >
-                                        <span
-                                            className={cn(
-                                                'block w-4 h-4 rounded-full ring-1 ring-border',
-                                                currentSwatch.bg
-                                            )}
-                                        />
-                                    </Button>
-                                </DropdownMenuTrigger>
-                            </TooltipTrigger>
-                            <TooltipContent side="left" sideOffset={8}>
-                                Highlight color
-                            </TooltipContent>
-                        </Tooltip>
-                        <DropdownMenuContent side="left" align="start" className="min-w-0">
-                            <div className="flex gap-1 p-1">
-                                {HIGHLIGHT_COLOR_SWATCHES.map(({ color, bg }) => (
-                                    <button
-                                        key={color}
-                                        type="button"
-                                        onClick={() => setHighlightColor(color)}
-                                        className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
-                                            highlightColor === color ? 'ring-2 ring-offset-1 ring-gray-400' : ''
-                                        }`}
-                                        title={color}
-                                    />
-                                ))}
-                            </div>
-                        </DropdownMenuContent>
-                    </DropdownMenu>
                 )}
             </div>
         </TooltipProvider>

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -1,12 +1,20 @@
 import { CitePaperButton } from '@/components/CitePaperButton';
+import { HIGHLIGHT_COLOR_SWATCHES } from '@/components/pdf-viewer/highlightColors';
 import { Button } from '@/components/ui/button';
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import {
     Tooltip,
     TooltipContent,
     TooltipProvider,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
+import type { HighlightColor } from '@/lib/schema';
 import { cn } from '@/lib/utils';
+import { Eye, EyeOff } from 'lucide-react';
 import React from 'react';
 
 /** Primary panels where the toolbar sits higher (less gap under the top bar). */
@@ -21,6 +29,10 @@ interface PaperSidebarProps {
             icon: React.ComponentType<{ className?: string }>;
         }[];
     };
+    highlightColor?: HighlightColor;
+    setHighlightColor?: (color: HighlightColor) => void;
+    showAnnotationCards?: boolean;
+    onToggleAnnotationCards?: () => void;
 }
 
 function NavButton({ item, rightSideFunction, setRightSideFunction }: {
@@ -50,11 +62,21 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
     );
 }
 
-export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset }: PaperSidebarProps) {
+export function PaperSidebar({
+    rightSideFunction,
+    setRightSideFunction,
+    PaperToolset,
+    highlightColor,
+    setHighlightColor,
+    showAnnotationCards,
+    onToggleAnnotationCards,
+}: PaperSidebarProps) {
     const beforeReadTool = PaperToolset.nav.filter(item => item.name !== 'Read');
     const readTool = PaperToolset.nav.find(item => item.name === 'Read');
 
     const toolbarTopClass = COMPACT_TOP_OFFSET_TOOLS.has(rightSideFunction) ? 'top-2' : 'top-14';
+    const currentSwatch =
+        HIGHLIGHT_COLOR_SWATCHES.find((c) => c.color === highlightColor) || HIGHLIGHT_COLOR_SWATCHES[2];
 
     return (
         <TooltipProvider>
@@ -79,6 +101,70 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                 </Tooltip>
                 {readTool && (
                     <NavButton item={readTool} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
+                )}
+                {onToggleAnnotationCards && showAnnotationCards !== undefined && (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                className={cn(
+                                    'h-7 w-7 p-0 rounded-md',
+                                    showAnnotationCards
+                                        ? 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
+                                        : 'text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200'
+                                )}
+                                onClick={onToggleAnnotationCards}
+                                aria-label={showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
+                            >
+                                {showAnnotationCards ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="left" sideOffset={8}>
+                            {showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
+                        </TooltipContent>
+                    </Tooltip>
+                )}
+                {highlightColor !== undefined && setHighlightColor && (
+                    <DropdownMenu>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <DropdownMenuTrigger asChild>
+                                    <Button
+                                        type="button"
+                                        variant="ghost"
+                                        className="h-7 w-7 p-0 rounded-full"
+                                        aria-label="Highlight color"
+                                    >
+                                        <span
+                                            className={cn(
+                                                'block w-4 h-4 rounded-full ring-1 ring-border',
+                                                currentSwatch.bg
+                                            )}
+                                        />
+                                    </Button>
+                                </DropdownMenuTrigger>
+                            </TooltipTrigger>
+                            <TooltipContent side="left" sideOffset={8}>
+                                Highlight color
+                            </TooltipContent>
+                        </Tooltip>
+                        <DropdownMenuContent side="left" align="start" className="min-w-0">
+                            <div className="flex gap-1 p-1">
+                                {HIGHLIGHT_COLOR_SWATCHES.map(({ color, bg }) => (
+                                    <button
+                                        key={color}
+                                        type="button"
+                                        onClick={() => setHighlightColor(color)}
+                                        className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
+                                            highlightColor === color ? 'ring-2 ring-offset-1 ring-gray-400' : ''
+                                        }`}
+                                        title={color}
+                                    />
+                                ))}
+                            </div>
+                        </DropdownMenuContent>
+                    </DropdownMenu>
                 )}
             </div>
         </TooltipProvider>

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -32,14 +32,14 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
             <TooltipTrigger asChild>
                 <Button
                     variant="ghost"
-                    className={`h-10 w-10 p-0 rounded-md ${
+                    className={`h-7 w-7 p-0 rounded-md ${
                         item.name === rightSideFunction
                             ? 'bg-blue-500 dark:bg-blue-500 text-blue-100 dark:text-blue-100 hover:bg-blue-600 dark:hover:bg-blue-600'
                             : 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
                     }`}
                     onClick={() => setRightSideFunction(item.name)}
                 >
-                    <item.icon className="h-5 w-5" />
+                    <item.icon className="h-4 w-4" />
                 </Button>
             </TooltipTrigger>
             <TooltipContent side="left" sideOffset={8}>
@@ -55,7 +55,7 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
 
     return (
         <TooltipProvider>
-            <div className="absolute right-2 top-14 z-20 flex flex-col gap-1 p-1.5 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-md">
+            <div className="absolute right-2 top-14 z-20 flex flex-col gap-0.5 p-1 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-md">
                 {beforeFocus.map((item) => (
                     <NavButton key={item.name} item={item} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
                 ))}
@@ -74,7 +74,7 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                     <TooltipTrigger asChild>
                         <Button
                             variant="ghost"
-                            className={`h-10 w-10 p-0 rounded-md ${
+                            className={`h-7 w-7 p-0 rounded-md ${
                                 showAnnotationCards
                                     ? 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
                                     : 'text-muted-foreground hover:bg-muted'
@@ -82,8 +82,8 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                             onClick={onToggleAnnotationCards}
                         >
                             {showAnnotationCards
-                                ? <Eye className="h-5 w-5" />
-                                : <EyeOff className="h-5 w-5" />
+                                ? <Eye className="h-4 w-4" />
+                                : <EyeOff className="h-4 w-4" />
                             }
                         </Button>
                     </TooltipTrigger>

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import { CitePaperButton } from '@/components/CitePaperButton';
 import { Button } from '@/components/ui/button';
 import {
     Tooltip,
@@ -6,8 +6,12 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { CitePaperButton } from '@/components/CitePaperButton';
+import { cn } from '@/lib/utils';
 import { Eye, EyeOff } from 'lucide-react';
+import React from 'react';
+
+/** Primary panels where the toolbar sits higher (less gap under the top bar). */
+const COMPACT_TOP_OFFSET_TOOLS = new Set(['Chat', 'Annotations', 'Audio']);
 
 interface PaperSidebarProps {
     rightSideFunction: string;
@@ -34,8 +38,8 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
                     variant="ghost"
                     className={`h-7 w-7 p-0 rounded-md ${
                         item.name === rightSideFunction
-                            ? 'bg-blue-500 dark:bg-blue-500 text-blue-100 dark:text-blue-100 hover:bg-blue-600 dark:hover:bg-blue-600'
-                            : 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
+                            ? 'bg-blue-500 text-blue-100 hover:bg-blue-600 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500'
+                            : 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
                     }`}
                     onClick={() => setRightSideFunction(item.name)}
                 >
@@ -53,9 +57,16 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
     const beforeFocus = PaperToolset.nav.filter(item => item.name !== 'Focus');
     const focusTool = PaperToolset.nav.find(item => item.name === 'Focus');
 
+    const toolbarTopClass = COMPACT_TOP_OFFSET_TOOLS.has(rightSideFunction) ? 'top-2' : 'top-14';
+
     return (
         <TooltipProvider>
-            <div className="absolute right-2 top-14 z-20 flex flex-col gap-0.5 p-1 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-md">
+            <div
+                className={cn(
+                    'absolute right-2 z-20 flex flex-col gap-0.5 p-1 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-lg transition-[top] duration-200 dark:bg-zinc-900/95 dark:border-zinc-600 dark:ring-1 dark:ring-white/10 dark:shadow-black/40',
+                    toolbarTopClass,
+                )}
+            >
                 {beforeFocus.map((item) => (
                     <NavButton key={item.name} item={item} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
                 ))}
@@ -76,8 +87,8 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                             variant="ghost"
                             className={`h-7 w-7 p-0 rounded-md ${
                                 showAnnotationCards
-                                    ? 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
-                                    : 'text-muted-foreground hover:bg-muted'
+                                    ? 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
+                                    : 'text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200'
                             }`}
                             onClick={onToggleAnnotationCards}
                         >

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -29,7 +29,7 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
             <TooltipTrigger asChild>
                 <Button
                     variant="ghost"
-                    className={`h-10 w-10 p-0 rounded-lg ${
+                    className={`h-10 w-10 p-0 rounded-md ${
                         item.name === rightSideFunction
                             ? 'bg-blue-500 dark:bg-blue-500 text-blue-100 dark:text-blue-100 hover:bg-blue-600 dark:hover:bg-blue-600'
                             : 'text-secondary-foreground hover:bg-blue-100 dark:hover:bg-blue-800'
@@ -52,7 +52,7 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
 
     return (
         <TooltipProvider>
-            <div className="absolute right-2 top-14 z-20 flex flex-col gap-1 p-1.5 bg-background/95 backdrop-blur-sm border border-border rounded-xl shadow-md">
+            <div className="absolute right-2 top-14 z-20 flex flex-col gap-1 p-1.5 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-md">
                 {beforeFocus.map((item) => (
                     <NavButton key={item.name} item={item} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
                 ))}

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -36,14 +36,14 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
             <TooltipTrigger asChild>
                 <Button
                     variant="ghost"
-                    className={`h-7 w-7 p-0 rounded-md ${
+                    className={`h-8 w-8 p-0 rounded-md ${
                         item.name === rightSideFunction
                             ? 'bg-blue-500 text-blue-100 hover:bg-blue-600 dark:bg-blue-600 dark:text-white dark:hover:bg-blue-500'
                             : 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
                     }`}
                     onClick={() => setRightSideFunction(item.name)}
                 >
-                    <item.icon className="h-4 w-4" />
+                    <item.icon className="h-5 w-5" />
                 </Button>
             </TooltipTrigger>
             <TooltipContent side="left" sideOffset={8}>
@@ -69,7 +69,7 @@ export function PaperSidebar({
         <TooltipProvider>
             <div
                 className={cn(
-                    'absolute right-2 z-20 flex flex-col gap-0.5 p-1 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-lg transition-[top] duration-200 dark:bg-zinc-900/95 dark:border-zinc-600 dark:ring-1 dark:ring-white/10 dark:shadow-black/40',
+                    'absolute right-2 z-20 flex flex-col gap-1 p-1 bg-background/95 backdrop-blur-sm border border-border rounded-lg shadow-lg transition-[top] duration-200 dark:bg-zinc-900/95 dark:border-zinc-600 dark:ring-1 dark:ring-white/10 dark:shadow-black/40',
                     toolbarTopClass,
                 )}
             >
@@ -86,7 +86,7 @@ export function PaperSidebar({
                                 type="button"
                                 variant="ghost"
                                 className={cn(
-                                    'h-7 w-7 p-0 rounded-md',
+                                    'h-8 w-8 p-0 rounded-md',
                                     showAnnotationCards
                                         ? 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
                                         : 'text-muted-foreground hover:bg-blue-100 dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200'
@@ -94,7 +94,7 @@ export function PaperSidebar({
                                 onClick={onToggleAnnotationCards}
                                 aria-label={showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
                             >
-                                {showAnnotationCards ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                                {showAnnotationCards ? <Eye className="h-5 w-5" /> : <EyeOff className="h-5 w-5" />}
                             </Button>
                         </TooltipTrigger>
                         <TooltipContent side="left" sideOffset={8}>

--- a/client/src/components/PaperSidebar.tsx
+++ b/client/src/components/PaperSidebar.tsx
@@ -7,7 +7,6 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import { Eye, EyeOff } from 'lucide-react';
 import React from 'react';
 
 /** Primary panels where the toolbar sits higher (less gap under the top bar). */
@@ -22,8 +21,6 @@ interface PaperSidebarProps {
             icon: React.ComponentType<{ className?: string }>;
         }[];
     };
-    showAnnotationCards: boolean;
-    onToggleAnnotationCards: () => void;
 }
 
 function NavButton({ item, rightSideFunction, setRightSideFunction }: {
@@ -53,9 +50,9 @@ function NavButton({ item, rightSideFunction, setRightSideFunction }: {
     );
 }
 
-export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset, showAnnotationCards, onToggleAnnotationCards }: PaperSidebarProps) {
-    const beforeFocus = PaperToolset.nav.filter(item => item.name !== 'Focus');
-    const focusTool = PaperToolset.nav.find(item => item.name === 'Focus');
+export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToolset }: PaperSidebarProps) {
+    const beforeReadTool = PaperToolset.nav.filter(item => item.name !== 'Read');
+    const readTool = PaperToolset.nav.find(item => item.name === 'Read');
 
     const toolbarTopClass = COMPACT_TOP_OFFSET_TOOLS.has(rightSideFunction) ? 'top-2' : 'top-14';
 
@@ -67,7 +64,7 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                     toolbarTopClass,
                 )}
             >
-                {beforeFocus.map((item) => (
+                {beforeReadTool.map((item) => (
                     <NavButton key={item.name} item={item} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
                 ))}
                 <Tooltip>
@@ -80,30 +77,8 @@ export function PaperSidebar({ rightSideFunction, setRightSideFunction, PaperToo
                         Cite
                     </TooltipContent>
                 </Tooltip>
-                {/* Annotation cards visibility toggle */}
-                <Tooltip>
-                    <TooltipTrigger asChild>
-                        <Button
-                            variant="ghost"
-                            className={`h-7 w-7 p-0 rounded-md ${
-                                showAnnotationCards
-                                    ? 'text-secondary-foreground hover:bg-blue-100 dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground'
-                                    : 'text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200'
-                            }`}
-                            onClick={onToggleAnnotationCards}
-                        >
-                            {showAnnotationCards
-                                ? <Eye className="h-4 w-4" />
-                                : <EyeOff className="h-4 w-4" />
-                            }
-                        </Button>
-                    </TooltipTrigger>
-                    <TooltipContent side="left" sideOffset={8}>
-                        {showAnnotationCards ? 'Hide annotations' : 'Show annotations'}
-                    </TooltipContent>
-                </Tooltip>
-                {focusTool && (
-                    <NavButton item={focusTool} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
+                {readTool && (
+                    <NavButton item={readTool} rightSideFunction={rightSideFunction} setRightSideFunction={setRightSideFunction} />
                 )}
             </div>
         </TooltipProvider>

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -93,6 +93,8 @@ interface PdfHighlighterViewerProps {
 	onOverlaysCreated?: (positions: Map<string, RenderedHighlightPosition>) => void;
 	onRefreshUrl?: () => Promise<string | null>;
 	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
+	updateAnnotation?: (annotationId: string, content: string) => Promise<unknown> | void;
+	removeAnnotation?: (annotationId: string) => void;
 	currentUser?: BasicUser | null;
 	showAnnotationCards?: boolean;
 }
@@ -121,6 +123,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		onOverlaysCreated,
 		onRefreshUrl,
 		addAnnotation,
+		updateAnnotation,
+		removeAnnotation,
 		currentUser,
 		annotations,
 		showAnnotationCards = true,
@@ -133,8 +137,10 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		left: number;
 		scrollContainer: Element;
 		initialContent?: string;
+		annotationId?: string;
 	}
 	const [annotationCards, setAnnotationCards] = useState<AnnotationCardEntry[]>([]);
+	const [cardHeights, setCardHeights] = useState<Map<string, number>>(new Map());
 	const [selectionRectTop, setSelectionRectTop] = useState<number | null>(null);
 	// Holds position computed during onAnnotate when activeHighlight isn't set yet (new text selection)
 	const [pendingAnnotationPos, setPendingAnnotationPos] = useState<{ top: number; left: number; scrollContainer: Element } | null>(null);
@@ -301,8 +307,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				const range = domSelection.getRangeAt(0);
 				const rect = range.getBoundingClientRect();
 				setTooltipPosition({
-					x: rect.right,
-					y: rect.top + rect.height / 2,
+					x: rect.left,
+					y: rect.bottom,
 				});
 				setSelectionRectTop(rect.top);
 			}
@@ -367,7 +373,22 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			// and scroll to center the card (at its natural stored position) in the viewport
 			const card = annotationCards.find(c => c.highlightId === viewportHighlight.id);
 			if (!card) {
-				setTooltipPosition({ x: event.clientX, y: event.clientY });
+				const target = event.target as HTMLElement;
+				const partsContainer = target.classList.contains('TextHighlight__parts')
+					? target
+					: (target.closest('.TextHighlight__parts') as HTMLElement | null);
+				let anchorX = event.clientX;
+				let anchorY = event.clientY + 20;
+				if (partsContainer) {
+					const parts = Array.from(partsContainer.querySelectorAll('.TextHighlight__part'));
+					if (parts.length > 0) {
+						const rects = parts.map(p => p.getBoundingClientRect());
+						const bottomRect = rects.reduce((prev, curr) => curr.top > prev.top ? curr : prev);
+						anchorX = bottomRect.left;
+						anchorY = bottomRect.bottom;
+					}
+				}
+				setTooltipPosition({ x: anchorX, y: anchorY });
 			} else {
 				const container = card.scrollContainer as HTMLElement;
 				const targetScrollTop = card.top - container.clientHeight / 2;
@@ -389,10 +410,13 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		if (!tooltipPosition) return;
 
 		const handleOutsideClick = (e: MouseEvent) => {
+			const target = e.target as HTMLElement;
+			// Let handleHighlightClick handle highlight clicks — don't close here
+			if (target.closest?.('.TextHighlight__parts, .TextHighlight__part')) return;
 			const tooltipElement = document.querySelector(".fixed.z-30");
 			if (!tooltipElement) return;
 
-			if (!tooltipElement.contains(e.target as Node)) {
+			if (!tooltipElement.contains(target)) {
 				setTimeout(() => {
 					setIsHighlightInteraction(false);
 					setSelectedText("");
@@ -444,15 +468,15 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		if (!annotations.length || !highlights.length) return;
 
 		// Group annotations by highlight_id, keep the first (earliest) per highlight
-		const byHighlight = new Map<string, string>();
+		const byHighlight = new Map<string, { content: string; annotationId: string }>();
 		for (const ann of annotations) {
 			if (!byHighlight.has(ann.highlight_id)) {
-				byHighlight.set(ann.highlight_id, ann.content);
+				byHighlight.set(ann.highlight_id, { content: ann.content, annotationId: ann.id });
 			}
 		}
 
 		const restored: AnnotationCardEntry[] = [];
-		byHighlight.forEach((content, highlightId) => {
+		byHighlight.forEach(({ content, annotationId }, highlightId) => {
 			const highlight = highlights.find(h => h.id === highlightId);
 			if (!highlight?.position || !highlight.page_number) return;
 
@@ -470,6 +494,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				left: pageDiv.offsetLeft + pageDiv.offsetWidth + 8,
 				scrollContainer,
 				initialContent: content,
+				annotationId,
 			});
 		});
 
@@ -722,7 +747,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 						setActiveHighlight(highlight);
 						setIsHighlightInteraction(true);
 						setSelectedText(highlight.raw_text);
-						setTooltipPosition({ x: e.clientX, y: e.clientY });
+					const rect = (e.target as HTMLElement).getBoundingClientRect();
+				setTooltipPosition({ x: rect.left, y: (e as MouseEvent).clientY + 20 });
 					});
 				});
 			}
@@ -979,11 +1005,11 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 						? pdfPage.getBoundingClientRect().right + 8
 						: window.innerWidth * 0.6;
 
-					const pos = {
-						top: (selectionRectTop ?? y) - containerRect.top + scrollTop,
-						left: pdfRight - containerRect.left,
-						scrollContainer,
-					};
+				const pos = {
+					top: (selectionRectTop ?? y) - containerRect.top + scrollTop,
+					left: pdfRight - containerRect.left,
+					scrollContainer,
+				};
 
 					if (isHighlightInteraction && activeHighlight) {
 						// User clicked an existing highlight — ID is already known, create card immediately
@@ -1001,7 +1027,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 
 	{/* Inline Annotation Cards — one per annotated highlight, persists until closed */}
 	{showAnnotationCards && addAnnotation && (() => {
-		const CARD_HEIGHT = 120;
+		const FALLBACK_HEIGHT = 120;
 		const GAP = 8;
 		const activeId = activeHighlight?.id;
 		const sorted = [...annotationCards].sort((a, b) => a.top - b.top);
@@ -1009,29 +1035,33 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 
 		let adjusted: typeof sorted;
 		if (activeIdx === -1) {
-			// No active card — standard downward pass
+			// No active card — standard downward pass using real heights
 			let prevBottom = -Infinity;
 			adjusted = sorted.map(card => {
+				const h = cardHeights.get(card.highlightId) ?? FALLBACK_HEIGHT;
 				const top = Math.max(card.top, prevBottom + GAP);
-				prevBottom = top + CARD_HEIGHT;
+				prevBottom = top + h;
 				return { ...card, top };
 			});
 		} else {
 			adjusted = [...sorted];
 			// Active card sits at its exact top
-			// Push cards ABOVE upward so they don't overlap the active card
+			// Push cards ABOVE upward using each card's real height
 			let nextCardTop = sorted[activeIdx].top;
 			for (let i = activeIdx - 1; i >= 0; i--) {
-				const top = Math.min(sorted[i].top, Math.max(0, nextCardTop - GAP - CARD_HEIGHT));
+				const h = cardHeights.get(sorted[i].highlightId) ?? FALLBACK_HEIGHT;
+				const top = Math.min(sorted[i].top, Math.max(0, nextCardTop - GAP - h));
 				adjusted[i] = { ...sorted[i], top };
 				nextCardTop = adjusted[i].top;
 			}
-			// Push cards BELOW downward
-			let prevBottom = sorted[activeIdx].top + CARD_HEIGHT;
+			// Push cards BELOW downward using real heights
+			const activeH = cardHeights.get(sorted[activeIdx].highlightId) ?? FALLBACK_HEIGHT;
+			let prevBottom = sorted[activeIdx].top + activeH;
 			for (let i = activeIdx + 1; i < sorted.length; i++) {
+				const h = cardHeights.get(sorted[i].highlightId) ?? FALLBACK_HEIGHT;
 				const top = Math.max(sorted[i].top, prevBottom + GAP);
 				adjusted[i] = { ...sorted[i], top };
-				prevBottom = adjusted[i].top + CARD_HEIGHT;
+				prevBottom = adjusted[i].top + h;
 			}
 		}
 		return adjusted.map(card =>
@@ -1042,13 +1072,35 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					topPosition={card.top}
 					leftPosition={card.left}
 					initialContent={card.initialContent}
+					annotationId={card.annotationId}
 					isActive={card.highlightId === activeId}
 					user={currentUser ?? null}
-					addAnnotation={addAnnotation}
+				addAnnotation={addAnnotation}
+				updateAnnotation={updateAnnotation}
+				onHeightChange={(h) =>
+						setCardHeights(prev => {
+							const next = new Map(prev);
+							next.set(card.highlightId, h);
+							return next;
+						})
+					}
+					onAnnotationSaved={(savedId) =>
+						setAnnotationCards(prev => prev.map(c =>
+							c.highlightId === card.highlightId ? { ...c, annotationId: savedId } : c
+						))
+					}
+					onDelete={() => {
+						if (card.annotationId && removeAnnotation) removeAnnotation(card.annotationId);
+						setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
+						setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
+						setIsAnnotating(false);
+						setSelectionRectTop(null);
+					}}
 					onClose={() => {
 						setIsAnnotating(false);
 						setSelectionRectTop(null);
 						setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
+						setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
 					}}
 				/>,
 				card.scrollContainer

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -151,6 +151,9 @@ interface PdfHighlighterViewerProps {
 	onAnnotateViaSidePanel?: (payload: { highlightId: string }) => void;
 	/** When true, the side panel is taking horizontal space — left-align PDF pages to make room for margin cards. */
 	sidePanelOpen?: boolean;
+	/** Focus / read mode state for the PdfToolbar toggle. */
+	isReadMode?: boolean;
+	onToggleReadMode?: () => void;
 }
 
 /** Syncs PdfLoader's render-prop pdfDocument into parent state without calling setState during render. */
@@ -212,6 +215,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		annotationsPanelActive = false,
 		onAnnotateViaSidePanel,
 		sidePanelOpen = false,
+		isReadMode = false,
+		onToggleReadMode,
 	} = props;
 
 	// Position anchors for inline annotation cards
@@ -1616,6 +1621,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				setHighlightColor={setHighlightColor}
 				showAnnotationCards={showAnnotationCards}
 				onToggleAnnotationCards={onToggleAnnotationCards}
+				isReadMode={isReadMode}
+				onToggleReadMode={onToggleReadMode}
 			/>
 
 			{/* PDF Viewer — overflow-x-visible so margin annotation cards beside the page are not clipped */}

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -577,6 +577,19 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		return () => bus.off("pagerendered", onPageRendered);
 	}, [pdfReady, numPages, viewerReadyTick]);
 
+	// Reset the restore guard whenever the set of persisted annotation IDs changes (e.g.
+	// after an annotation is created or deleted on the server). This ensures that if the
+	// user dismissed an inline card during the current session, it will be re-created
+	// the next time the annotation list changes.
+	const annotationIdsKey = annotations.map(a => a.id).sort().join(',');
+	const prevAnnotationIdsKeyRef = useRef<string>('');
+	useEffect(() => {
+		if (annotationIdsKey !== prevAnnotationIdsKeyRef.current) {
+			prevAnnotationIdsKeyRef.current = annotationIdsKey;
+			hasRestoredRef.current = false;
+		}
+	}, [annotationIdsKey]);
+
 	// Restore annotation cards from server-persisted annotations on page load
 	useEffect(() => {
 		if (!pdfReady || hasRestoredRef.current) return;

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -570,6 +570,34 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			if (domSelection && domSelection.rangeCount > 0) {
 				const range = domSelection.getRangeAt(0);
 				const rect = range.getBoundingClientRect();
+				const clientRects = range.getClientRects();
+				// #region agent log
+				fetch("http://127.0.0.1:7848/ingest/1ffc24a3-d0c6-4802-9576-899d9a9fb32b", {
+					method: "POST",
+					headers: {
+						"Content-Type": "application/json",
+						"X-Debug-Session-Id": "434c20",
+					},
+					body: JSON.stringify({
+						sessionId: "434c20",
+						hypothesisId: "H1-H4",
+						location: "PdfHighlighterViewer.tsx:handleSelection",
+						message: "selection range rects",
+						data: {
+							union: {
+								top: rect.top,
+								bottom: rect.bottom,
+								left: rect.left,
+								height: rect.height,
+							},
+							clientRectCount: clientRects.length,
+							innerHeight: typeof window !== "undefined" ? window.innerHeight : null,
+						},
+						timestamp: Date.now(),
+						runId: "pre-fix",
+					}),
+				}).catch(() => {});
+				// #endregion
 				setTooltipPosition({
 					x: rect.left,
 					y: rect.bottom,

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -1630,7 +1630,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				className={cn(
 					"flex-1 min-h-0 overflow-x-visible overflow-y-hidden relative",
 					pdfHighlightsSuppressedForZoom && "pdf-zoom-layout-pending",
-					showAnnotationCards && sidePanelOpen && "pdf-align-left"
+					sidePanelOpen && (showAnnotationCards || (isAnnotating && !(annotationsPanelActive && !showAnnotationCards))) && "pdf-align-left"
 				)}
 			>
 				<PdfLoader

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useRef, useState, useCallback, useEffect, useMemo } from "react";
+import {
+	useRef,
+	useState,
+	useCallback,
+	useEffect,
+	useMemo,
+	type Dispatch,
+	type SetStateAction,
+} from "react";
 import { createPortal } from "react-dom";
 import {
 	PdfLoader,
@@ -143,6 +151,14 @@ interface PdfHighlighterViewerProps {
 	currentUser?: BasicUser | null;
 	showAnnotationCards?: boolean;
 	onToggleAnnotationCards?: () => void;
+	/** When true and inline cards are hidden, route annotate flows to the Annotations side panel */
+	annotationsPanelActive?: boolean;
+	onAnnotateViaSidePanel?: (payload: { highlightId: string }) => void;
+	/** Controlled highlight color (optional; defaults to internal state). */
+	highlightColor?: HighlightColor;
+	setHighlightColor?: Dispatch<SetStateAction<HighlightColor>>;
+	/** When false, color + annotation visibility live on PaperSidebar (desktop). Default true. */
+	showToolbarColorAndEye?: boolean;
 }
 
 export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
@@ -175,6 +191,11 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		annotations,
 		showAnnotationCards = true,
 		onToggleAnnotationCards,
+		annotationsPanelActive = false,
+		onAnnotateViaSidePanel,
+		highlightColor: highlightColorProp,
+		setHighlightColor: setHighlightColorProp,
+		showToolbarColorAndEye = true,
 	} = props;
 
 	// Position anchors for inline annotation cards
@@ -190,6 +211,10 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	const [selectionRectTop, setSelectionRectTop] = useState<number | null>(null);
 	// Holds position computed during onAnnotate when activeHighlight isn't set yet (new text selection)
 	const [pendingAnnotationPos, setPendingAnnotationPos] = useState<{ top: number; left: number; scrollContainer: Element } | null>(null);
+	/** New selection annotate while Annotations panel is open — wait for highlight id then notify parent */
+	const [pendingSidePanelAnnotate, setPendingSidePanelAnnotate] = useState(false);
+	/** When inline cards are hidden, user clicked a highlight with a persisted thread — show that card only */
+	const [peekAnnotationCardHighlightId, setPeekAnnotationCardHighlightId] = useState<string | null>(null);
 	// Guard: restore annotation cards from server data only once per mount
 	const hasRestoredRef = useRef(false);
 
@@ -265,7 +290,9 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	 * effect re-run once the viewer is genuinely available.
 	 */
 	const [viewerReadyTick, setViewerReadyTick] = useState(0);
-	const [highlightColor, setHighlightColor] = useState<HighlightColor>("blue");
+	const [internalHighlightColor, setInternalHighlightColor] = useState<HighlightColor>("blue");
+	const highlightColor = highlightColorProp ?? internalHighlightColor;
+	const setHighlightColor = setHighlightColorProp ?? setInternalHighlightColor;
 
 	// Search hook
 	const search = usePdfSearch({
@@ -515,6 +542,39 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		});
 	}, [syncAnnotationCardPositions]);
 
+	const highlightHasPersistedAnnotations = useCallback(
+		(highlightId: string | undefined) =>
+			Boolean(highlightId && annotations.some((a) => a.highlight_id === highlightId)),
+		[annotations]
+	);
+
+	const ensureAnnotationCardEntry = useCallback(
+		(highlightId: string) => {
+			setAnnotationCards((prev) => {
+				if (prev.some((c) => c.highlightId === highlightId)) return prev;
+				const h = highlights.find((x) => x.id === highlightId);
+				if (!h?.position || !h.page_number) return prev;
+				const viewer = highlighterUtilsRef.current?.getViewer();
+				const scrollContainer = viewer?.container as HTMLElement | undefined;
+				if (!viewer || !scrollContainer) return prev;
+				const anchor = getAnnotationCardAnchorForHighlight(h, viewer, scrollContainer);
+				if (!anchor) return prev;
+				const firstAnn = annotations.find((a) => a.highlight_id === highlightId);
+				return [
+					...prev,
+					{
+						highlightId,
+						top: anchor.top,
+						left: anchor.left,
+						scrollContainer,
+						annotationId: firstAnn?.id,
+					},
+				];
+			});
+		},
+		[highlights, annotations]
+	);
+
 	// Handle selection
 	const handleSelection = useCallback(
 		(selection: PdfSelection) => {
@@ -581,7 +641,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			setSelectedText(viewportHighlight.content?.text || viewportHighlight.raw_text || "");
 			setSelectionRectTop(event.clientY);
 
-			const originalHighlight = extendedHighlights.find(h => h.id === viewportHighlight.id);
+			const hid = viewportHighlight.id;
+			const originalHighlight = hid ? extendedHighlights.find((h) => h.id === hid) : undefined;
 			if (originalHighlight) {
 				const paperHighlight = extendedToPaperHighlight(originalHighlight);
 				// Don't scroll - the highlight is already in view since user just clicked it
@@ -589,26 +650,69 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				setActiveHighlight(paperHighlight);
 			}
 
-			// If this highlight already has an open annotation card, skip the context menu
-			// and scroll to center the card (at its natural stored position) in the viewport
-			const card = annotationCards.find(c => c.highlightId === viewportHighlight.id);
-			if (!card) {
+			const openMenuAtHighlight = () => {
 				const target = event.target as HTMLElement;
-				const partsContainer = target.classList.contains('TextHighlight__parts')
+				const partsContainer = target.classList.contains("TextHighlight__parts")
 					? target
-					: (target.closest('.TextHighlight__parts') as HTMLElement | null);
+					: (target.closest(".TextHighlight__parts") as HTMLElement | null);
 				let anchorX = event.clientX;
 				let anchorY = event.clientY + 20;
 				if (partsContainer) {
-					const parts = Array.from(partsContainer.querySelectorAll('.TextHighlight__part'));
+					const parts = Array.from(partsContainer.querySelectorAll(".TextHighlight__part"));
 					if (parts.length > 0) {
-						const rects = parts.map(p => p.getBoundingClientRect());
-						const bottomRect = rects.reduce((prev, curr) => curr.top > prev.top ? curr : prev);
+						const rects = parts.map((p) => p.getBoundingClientRect());
+						const bottomRect = rects.reduce((prev, curr) =>
+							curr.top > prev.top ? curr : prev
+						);
 						anchorX = bottomRect.left;
 						anchorY = bottomRect.bottom;
 					}
 				}
 				setTooltipPosition({ x: anchorX, y: anchorY });
+			};
+
+			if (!hid) return;
+
+			const card = annotationCards.find((c) => c.highlightId === hid);
+			const hasPersisted = highlightHasPersistedAnnotations(hid);
+
+			if (showAnnotationCards) {
+				if (!card) {
+					openMenuAtHighlight();
+				} else {
+					const container = card.scrollContainer as HTMLElement;
+					const targetScrollTop = card.top - container.clientHeight / 2;
+					container.scrollTo({ top: Math.max(0, targetScrollTop), behavior: "smooth" });
+				}
+				return;
+			}
+
+			// Inline cards hidden: peek persisted thread when we can anchor a margin card
+			if (hasPersisted) {
+				const ph = originalHighlight
+					? extendedToPaperHighlight(originalHighlight)
+					: highlights.find((x) => x.id === hid);
+				if (ph?.position && ph.page_number) {
+					const viewer = highlighterUtilsRef.current?.getViewer();
+					const scrollContainer = viewer?.container as HTMLElement | undefined;
+					if (viewer && scrollContainer) {
+						const anchor = getAnnotationCardAnchorForHighlight(ph, viewer, scrollContainer);
+						if (anchor) {
+							setPeekAnnotationCardHighlightId(hid);
+							ensureAnnotationCardEntry(hid);
+							const targetScrollTop = anchor.top - scrollContainer.clientHeight / 2;
+							scrollContainer.scrollTo({
+								top: Math.max(0, targetScrollTop),
+								behavior: "smooth",
+							});
+							return;
+						}
+					}
+				}
+			}
+
+			if (!card) {
+				openMenuAtHighlight();
 			} else {
 				const container = card.scrollContainer as HTMLElement;
 				const targetScrollTop = card.top - container.clientHeight / 2;
@@ -622,6 +726,10 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			setActiveHighlight,
 			extendedHighlights,
 			annotationCards,
+			showAnnotationCards,
+			highlightHasPersistedAnnotations,
+			ensureAnnotationCardEntry,
+			highlights,
 		]
 	);
 
@@ -672,6 +780,10 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			if (!target) return;
 
 			if (target.closest("[data-inline-annotation-card]")) return;
+			// Entire highlight layer + our wrapper: mousedown target is not always a .TextHighlight__part
+			// (gaps, wrapper, or stacking) but the user is still interacting with a highlight.
+			if (target.closest(".PdfHighlighter__highlight-layer")) return;
+			if (target.closest("[data-pdf-text-highlight]")) return;
 			if (target.closest(".TextHighlight__parts, .TextHighlight__part")) return;
 			if (target.closest("[data-annotation-sidebar-row]")) return;
 			if (target.closest("[data-inline-annotation-menu]")) return;
@@ -683,18 +795,62 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		return () => document.removeEventListener("mousedown", handleDocumentMouseDown);
 	}, [activeHighlight, setActiveHighlight]);
 
+	useEffect(() => {
+		if (!activeHighlight) setPeekAnnotationCardHighlightId(null);
+	}, [activeHighlight]);
+
+	useEffect(() => {
+		if (showAnnotationCards) setPeekAnnotationCardHighlightId(null);
+	}, [showAnnotationCards]);
+
 	// When a new highlight is saved after a text selection annotate, create the pending card
+	// or notify the Annotations side panel when margin cards are suppressed
 	useEffect(() => {
 		if (!addAnnotation) return;
 		const hid = activeHighlight?.id;
-		if (isAnnotating && hid && pendingAnnotationPos) {
-			setAnnotationCards(prev => {
-				const exists = prev.find(c => c.highlightId === hid);
-				return exists ? prev : [...prev, { highlightId: hid, ...pendingAnnotationPos }];
-			});
+		if (!isAnnotating || !hid) return;
+
+		const useSidePanel =
+			!showAnnotationCards && annotationsPanelActive && Boolean(onAnnotateViaSidePanel);
+
+		if (pendingAnnotationPos) {
+			if (useSidePanel) {
+				onAnnotateViaSidePanel?.({ highlightId: hid });
+			} else {
+				setAnnotationCards(prev => {
+					const exists = prev.find(c => c.highlightId === hid);
+					return exists ? prev : [...prev, { highlightId: hid, ...pendingAnnotationPos }];
+				});
+				// Margin cards hidden: portal list is peek-filtered — show the new compose card
+				if (!showAnnotationCards) {
+					setPeekAnnotationCardHighlightId(hid);
+				}
+			}
 			setPendingAnnotationPos(null);
 		}
-	}, [addAnnotation, isAnnotating, activeHighlight, pendingAnnotationPos]);
+
+		if (pendingSidePanelAnnotate && useSidePanel) {
+			onAnnotateViaSidePanel?.({ highlightId: hid });
+			setPendingSidePanelAnnotate(false);
+		}
+	}, [
+		addAnnotation,
+		isAnnotating,
+		activeHighlight,
+		pendingAnnotationPos,
+		pendingSidePanelAnnotate,
+		showAnnotationCards,
+		annotationsPanelActive,
+		onAnnotateViaSidePanel,
+	]);
+
+	useEffect(() => {
+		if (!isAnnotating) setPendingSidePanelAnnotate(false);
+	}, [isAnnotating]);
+
+	useEffect(() => {
+		if (!annotationsPanelActive) setPendingSidePanelAnnotate(false);
+	}, [annotationsPanelActive]);
 
 	// Poll for the PDF.js viewer instance becoming available.
 	// The library initialises it with a 100ms debounce, so getViewer() returns null
@@ -762,6 +918,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	// Restore annotation cards from server-persisted annotations on page load
 	useEffect(() => {
 		if (!pdfReady || hasRestoredRef.current) return;
+		// Margin cards are not shown — skip until the user returns to a mode that shows them
+		if (!showAnnotationCards) return;
 
 		const viewer = highlighterUtilsRef.current?.getViewer();
 		const scrollContainer = viewer?.container as HTMLElement | undefined;
@@ -821,7 +979,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			// No annotations to restore at all — nothing to do, lock to stop retrying.
 			hasRestoredRef.current = true;
 		}
-	}, [pdfReady, annotations, highlights, pdfLayoutTick, scale, numPages, viewerReadyTick]);
+	}, [pdfReady, annotations, highlights, pdfLayoutTick, scale, numPages, viewerReadyTick, showAnnotationCards]);
 
 	// Auto-remove card entries whose entire annotation thread has been deleted
 	useEffect(() => {
@@ -1123,8 +1281,39 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 						setActiveHighlight(highlight);
 						setIsHighlightInteraction(true);
 						setSelectedText(highlight.raw_text);
-					const rect = (e.target as HTMLElement).getBoundingClientRect();
-				setTooltipPosition({ x: rect.left, y: (e as MouseEvent).clientY + 20 });
+						const hid = highlight.id;
+						if (
+							hid &&
+							!showAnnotationCards &&
+							highlightHasPersistedAnnotations(hid) &&
+							highlight.position &&
+							highlight.page_number
+						) {
+							const viewer = highlighterUtilsRef.current?.getViewer();
+							const scrollContainer = viewer?.container as HTMLElement | undefined;
+							if (viewer && scrollContainer) {
+								const anchor = getAnnotationCardAnchorForHighlight(
+									highlight,
+									viewer,
+									scrollContainer
+								);
+								if (anchor) {
+									setPeekAnnotationCardHighlightId(hid);
+									ensureAnnotationCardEntry(hid);
+									const targetScrollTop = anchor.top - scrollContainer.clientHeight / 2;
+									scrollContainer.scrollTo({
+										top: Math.max(0, targetScrollTop),
+										behavior: "smooth",
+									});
+									return;
+								}
+							}
+						}
+						const rect = (e.target as HTMLElement).getBoundingClientRect();
+						setTooltipPosition({
+							x: rect.left,
+							y: (e as MouseEvent).clientY + 20,
+						});
 					});
 				});
 			}
@@ -1263,7 +1452,16 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			pendingTimeouts.forEach((timeout) => clearTimeout(timeout));
 			pendingTimeouts.clear();
 		};
-	}, [pdfReady, highlights, scale, onOverlaysCreated, activeHighlight]);
+	}, [
+		pdfReady,
+		highlights,
+		scale,
+		onOverlaysCreated,
+		activeHighlight,
+		showAnnotationCards,
+		highlightHasPersistedAnnotations,
+		ensureAnnotationCardEntry,
+	]);
 
 	return (
 		<div
@@ -1299,6 +1497,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				setHighlightColor={setHighlightColor}
 				showAnnotationCards={showAnnotationCards}
 				onToggleAnnotationCards={onToggleAnnotationCards}
+				showColorAndEye={showToolbarColorAndEye}
 			/>
 
 			{/* PDF Viewer — overflow-x-visible so margin annotation cards beside the page are not clipped */}
@@ -1382,6 +1581,17 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					const scrollContainer = viewer?.container as HTMLElement | undefined;
 					if (!viewer || !scrollContainer) return;
 
+					const useSidePanel =
+						!showAnnotationCards && annotationsPanelActive && Boolean(onAnnotateViaSidePanel);
+					if (useSidePanel) {
+						if (isHighlightInteraction && activeHighlight?.id) {
+							onAnnotateViaSidePanel?.({ highlightId: activeHighlight.id });
+						} else {
+							setPendingSidePanelAnnotate(true);
+						}
+						return;
+					}
+
 					const containerRect = scrollContainer.getBoundingClientRect();
 					const scrollTop = scrollContainer.scrollTop;
 					const scrollLeft = scrollContainer.scrollLeft;
@@ -1428,6 +1638,9 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 							const exists = prev.find(c => c.highlightId === hid);
 							return exists ? prev : [...prev, { highlightId: hid, ...pos }];
 						});
+						if (!showAnnotationCards) {
+							setPeekAnnotationCardHighlightId(hid);
+						}
 					} else {
 						// New text selection — highlight not yet saved; wait for async server response
 						setPendingAnnotationPos(pos);
@@ -1437,11 +1650,15 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		)}
 
 	{/* Inline Annotation Cards — one per annotated highlight, persists until closed */}
-	{showAnnotationCards && (() => {
+	{(showAnnotationCards || peekAnnotationCardHighlightId !== null) && (() => {
 		const FALLBACK_HEIGHT = 120;
 		const GAP = 8;
 		const activeId = activeHighlight?.id;
-		const sorted = [...annotationCards].sort((a, b) => a.top - b.top);
+		const peekId = peekAnnotationCardHighlightId;
+		const cardsForLayout = showAnnotationCards
+			? annotationCards
+			: annotationCards.filter((c) => c.highlightId === peekId);
+		const sorted = [...cardsForLayout].sort((a, b) => a.top - b.top);
 		const activeIdx = sorted.findIndex(c => c.highlightId === activeId);
 
 		let adjusted: typeof sorted;
@@ -1503,6 +1720,9 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					onClose={() => {
 						setIsAnnotating(false);
 						setSelectionRectTop(null);
+						if (peekAnnotationCardHighlightId === card.highlightId) {
+							setPeekAnnotationCardHighlightId(null);
+						}
 						// Only remove unsaved cards — saved annotation threads persist until all comments are deleted
 						if (!card.annotationId) {
 							setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -27,6 +27,7 @@ import EnigmaticLoadingExperience from "@/components/EnigmaticLoadingExperience"
 import { PaperStatus } from "./utils/PdfStatus";
 import InlineAnnotationMenu from "./InlineAnnotationMenu";
 import { InlineAnnotationCard } from "./InlineAnnotationCard";
+import { AnnotationHoverCard } from "./AnnotationHoverCard";
 import { BasicUser } from "@/lib/auth";
 
 import {
@@ -230,6 +231,9 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	const [pendingSidePanelAnnotate, setPendingSidePanelAnnotate] = useState(false);
 	/** When inline cards are hidden, user clicked a highlight with a persisted thread — show that card only */
 	const [peekAnnotationCardHighlightId, setPeekAnnotationCardHighlightId] = useState<string | null>(null);
+	/** Hover card: show annotations on highlight hover when margin cards are hidden */
+	const [hoverHighlightId, setHoverHighlightId] = useState<string | null>(null);
+	const [hoverPosition, setHoverPosition] = useState<{ x: number; y: number } | null>(null);
 	// Guard: restore annotation cards from server data only once per mount
 	const hasRestoredRef = useRef(false);
 
@@ -1107,6 +1111,63 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		}
 	}, [activeHighlight, extendedHighlights]);
 
+	// Hover card: show annotations on highlight hover when margin cards are hidden
+	useEffect(() => {
+		if (showAnnotationCards) {
+			setHoverHighlightId(null);
+			return;
+		}
+		const container = containerRef.current;
+		if (!container) return;
+
+		const getHighlightId = (target: EventTarget | null): string | null => {
+			const el = target as HTMLElement | null;
+			if (!el?.closest) return null;
+			// DOM overlay highlights
+			const overlay = el.closest<HTMLElement>(".text-match-highlight-overlay[data-highlight-id]");
+			if (overlay) return overlay.getAttribute("data-highlight-id");
+			// Positioned highlights from HighlightContainer
+			const positioned = el.closest<HTMLElement>("[data-pdf-text-highlight][data-highlight-id]");
+			if (positioned) return positioned.getAttribute("data-highlight-id");
+			return null;
+		};
+
+		const onMouseOver = (e: MouseEvent) => {
+			const hid = getHighlightId(e.target);
+			if (!hid) return;
+			// Only show if this highlight has persisted annotations
+			if (!annotations.some((a) => a.highlight_id === hid)) return;
+			setHoverHighlightId(hid);
+			setHoverPosition({ x: e.clientX + 12, y: e.clientY + 12 });
+		};
+
+		const onMouseOut = (e: MouseEvent) => {
+			const fromHid = getHighlightId(e.target);
+			const toHid = getHighlightId(e.relatedTarget);
+			// Only hide if we actually left the highlight (not moving between parts of the same highlight)
+			if (fromHid && fromHid === toHid) return;
+			if (fromHid) {
+				setHoverHighlightId(null);
+				setHoverPosition(null);
+			}
+		};
+
+		// Dismiss on click (highlight becomes active / tooltip opens)
+		const onMouseDown = () => {
+			setHoverHighlightId(null);
+			setHoverPosition(null);
+		};
+
+		container.addEventListener("mouseover", onMouseOver);
+		container.addEventListener("mouseout", onMouseOut);
+		container.addEventListener("mousedown", onMouseDown);
+		return () => {
+			container.removeEventListener("mouseover", onMouseOver);
+			container.removeEventListener("mouseout", onMouseOut);
+			container.removeEventListener("mousedown", onMouseDown);
+		};
+	}, [showAnnotationCards, annotations]);
+
 	// Update current page when user scrolls through the PDF
 	useEffect(() => {
 		if (!pdfReady) return;
@@ -1809,6 +1870,15 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			)
 		);
 	})()}
+
+			{/* Annotation hover card — shown on highlight hover when margin cards are hidden */}
+			{!showAnnotationCards && hoverHighlightId && hoverPosition && (
+				<AnnotationHoverCard
+					annotations={annotations.filter((a) => a.highlight_id === hoverHighlightId)}
+					position={hoverPosition}
+					user={currentUser ?? null}
+				/>
+			)}
 
 			{/* Scroll to top button */}
 			{showScrollToTop && (

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -61,6 +61,56 @@ export interface RenderedHighlightPosition {
 	page: number;
 }
 
+/** Matches `w-[280px]` on margin annotation cards */
+const ANNOTATION_CARD_WIDTH_PX = 280;
+const ANNOTATION_CARD_MARGIN_GAP_PX = 8;
+
+/**
+ * Anchor for margin annotation cards: right gutter by default, left gutter if the
+ * card would not fit to the right of the page in the scroll container.
+ */
+function getAnnotationCardAnchorForHighlight(
+	highlight: PaperHighlight,
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	viewer: any,
+	scrollContainer: HTMLElement
+): { top: number; left: number } | null {
+	if (!highlight.position || !highlight.page_number) return null;
+
+	const pageView = viewer.getPageView(highlight.page_number - 1);
+	if (!pageView?.div || !pageView?.viewport) return null;
+
+	const { div: pageDiv, viewport } = pageView;
+	const { boundingRect } = highlight.position;
+	const scaleY = viewport.height / boundingRect.height;
+
+	const containerRect = scrollContainer.getBoundingClientRect();
+	const pageRect = (pageDiv as HTMLElement).getBoundingClientRect();
+	const scrollLeft = scrollContainer.scrollLeft;
+
+	const top =
+		pageRect.top -
+		containerRect.top +
+		scrollContainer.scrollTop +
+		boundingRect.y1 * scaleY;
+
+	const pageRightContent = pageRect.right - containerRect.left + scrollLeft;
+	const pageLeftContent = pageRect.left - containerRect.left + scrollLeft;
+
+	const rightGutterLeft = pageRightContent + ANNOTATION_CARD_MARGIN_GAP_PX;
+	const leftGutterLeft = pageLeftContent - ANNOTATION_CARD_MARGIN_GAP_PX - ANNOTATION_CARD_WIDTH_PX;
+
+	let left = rightGutterLeft;
+	if (
+		rightGutterLeft + ANNOTATION_CARD_WIDTH_PX > scrollContainer.scrollWidth &&
+		leftGutterLeft >= 0
+	) {
+		left = leftGutterLeft;
+	}
+
+	return { top, left };
+}
+
 interface PdfHighlighterViewerProps {
 	pdfUrl: string;
 	explicitSearchTerm?: string;
@@ -205,6 +255,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	const [currentSelection, setCurrentSelection] = useState<PdfSelection | null>(null);
 	const [, setCurrentGhostHighlight] = useState<GhostHighlight | null>(null);
 	const [scale, setScale] = useState(1.0);
+	// Ref so ResizeObserver callbacks (which close over a stale scale) can re-apply the current scale
+	const scaleRef = useRef(1.0);
 	const [currentPage, setCurrentPage] = useState(1);
 	const [numPages, setNumPages] = useState<number | null>(null);
 	const [showScrollToTop] = useState(false);
@@ -252,6 +304,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	// Apply scale changes directly to the viewer
 	// (workaround for react-pdf-highlighter-extended not responding to pdfScaleValue prop changes)
 	useEffect(() => {
+		scaleRef.current = scale;
 		const viewer = highlighterUtilsRef.current?.getViewer();
 		if (viewer) {
 			viewer.currentScaleValue = String(scale);
@@ -306,6 +359,30 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			setCurrentPage(1);
 		}
 	}, []);
+
+	const syncAnnotationCardPositions = useCallback(() => {
+		setAnnotationCards((prev) => {
+			if (prev.length === 0) return prev;
+			const viewer = highlighterUtilsRef.current?.getViewer();
+			const scrollContainer = viewer?.container as HTMLElement | undefined;
+			if (!viewer || !scrollContainer) return prev;
+
+			let changed = false;
+			const next = prev.map((card) => {
+				const h = highlights.find((x) => x.id === card.highlightId);
+				if (!h?.position) return card;
+				const anchor = getAnnotationCardAnchorForHighlight(h, viewer, scrollContainer);
+				if (!anchor) return card;
+				const same =
+					Math.abs(anchor.top - card.top) < 0.5 &&
+					Math.abs(anchor.left - card.left) < 0.5;
+				if (same) return card;
+				changed = true;
+				return { ...card, top: anchor.top, left: anchor.left, scrollContainer };
+			});
+			return changed ? next : prev;
+		});
+	}, [highlights]);
 
 	// Handle selection
 	const handleSelection = useCallback(
@@ -521,7 +598,6 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			}
 		}
 
-		const containerRect = scrollContainer.getBoundingClientRect();
 		const restored: AnnotationCardEntry[] = [];
 		let missingPageView = 0;
 		let attempted = 0;
@@ -532,28 +608,16 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 
 			attempted++;
 
-			// eslint-disable-next-line @typescript-eslint/no-explicit-any
-			const pageView = (viewer as any).getPageView(highlight.page_number - 1);
-			if (!pageView?.div || !pageView?.viewport) {
+			const anchor = getAnnotationCardAnchorForHighlight(highlight, viewer, scrollContainer);
+			if (!anchor) {
 				missingPageView += 1;
 				return;
 			}
 
-			const { div: pageDiv, viewport } = pageView;
-			const { boundingRect } = highlight.position;
-			// scaleY converts from stored page-height units to current CSS pixels
-			const scaleY = viewport.height / boundingRect.height;
-
-			// Use getBoundingClientRect so the position is correct regardless of
-			// intermediate offset parents (.pdfViewer vs .PdfHighlighter scroll container).
-			const pageRect = (pageDiv as HTMLElement).getBoundingClientRect();
-			const top = pageRect.top - containerRect.top + scrollContainer.scrollTop + boundingRect.y1 * scaleY;
-			const left = pageRect.right - containerRect.left + 8;
-
 			restored.push({
 				highlightId,
-				top,
-				left,
+				top: anchor.top,
+				left: anchor.left,
 				scrollContainer,
 				initialContent: content,
 				annotationId,
@@ -577,6 +641,57 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			hasRestoredRef.current = true;
 		}
 	}, [pdfReady, annotations, highlights, pdfLayoutTick, scale, numPages, viewerReadyTick]);
+
+	// Keep margin card anchors in sync when zoom/layout changes (restore only sets initial positions once).
+	useEffect(() => {
+		if (!pdfReady) return;
+		syncAnnotationCardPositions();
+	}, [
+		pdfReady,
+		pdfLayoutTick,
+		viewerReadyTick,
+		annotationCards.length,
+		syncAnnotationCardPositions,
+	]);
+
+	// PDF scroll/resize does not trigger React state — re-sync card positions from live page geometry.
+	useEffect(() => {
+		if (!pdfReady) return;
+		const viewer = highlighterUtilsRef.current?.getViewer();
+		const el = viewer?.container as HTMLElement | undefined;
+		if (!el) return;
+
+		let rafId = 0;
+		const scheduleSync = () => {
+			if (rafId !== 0) return;
+			rafId = requestAnimationFrame(() => {
+				rafId = 0;
+				syncAnnotationCardPositions();
+			});
+		};
+
+		el.addEventListener("scroll", scheduleSync, { passive: true });
+		const ro = new ResizeObserver(() => {
+			// Re-apply correct scale synchronously before browser can paint.
+			// Our callback fires after the library's (registered earlier), so the library's stale
+			// ResizeObserver has already reset currentScaleValue by this point. Overriding it here
+			// (no setTimeout) ensures we correct it in the same rendering task, before any frame paint.
+			const v = highlighterUtilsRef.current?.getViewer();
+			if (v && v.currentScaleValue !== String(scaleRef.current)) {
+				v.currentScaleValue = String(scaleRef.current);
+			}
+			scheduleSync();
+		});
+		ro.observe(el);
+		window.addEventListener("resize", scheduleSync);
+
+		return () => {
+			el.removeEventListener("scroll", scheduleSync);
+			ro.disconnect();
+			window.removeEventListener("resize", scheduleSync);
+			if (rafId !== 0) cancelAnimationFrame(rafId);
+		};
+	}, [pdfReady, viewerReadyTick, syncAnnotationCardPositions]);
 
 	// Keep the module-level store in sync so HighlightContainer (in a separate React root) can react
 	useEffect(() => {
@@ -1069,22 +1184,48 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					setUserMessageReferences={setUserMessageReferences}
 			onAnnotate={(y) => {
 					if (!addAnnotation) return;
-					const scrollContainer = highlighterUtilsRef.current?.getViewer()?.container;
-					if (!scrollContainer) return;
+					const viewer = highlighterUtilsRef.current?.getViewer();
+					const scrollContainer = viewer?.container as HTMLElement | undefined;
+					if (!viewer || !scrollContainer) return;
+
 					const containerRect = scrollContainer.getBoundingClientRect();
 					const scrollTop = scrollContainer.scrollTop;
+					const scrollLeft = scrollContainer.scrollLeft;
 
-					const pdfPage = document.querySelector('#pdf-container .page')
-						?? document.querySelector('#pdf-container [data-page-number]');
-					const pdfRight = pdfPage
-						? pdfPage.getBoundingClientRect().right + 8
-						: window.innerWidth * 0.6;
+					let pos: { top: number; left: number; scrollContainer: Element };
 
-				const pos = {
-					top: (selectionRectTop ?? y) - containerRect.top + scrollTop,
-					left: pdfRight - containerRect.left,
-					scrollContainer,
-				};
+					if (isHighlightInteraction && activeHighlight?.id) {
+						const h = highlights.find((x) => x.id === activeHighlight.id);
+						const anchor =
+							h?.position && h.page_number
+								? getAnnotationCardAnchorForHighlight(h, viewer, scrollContainer)
+								: null;
+						if (anchor) {
+							pos = { ...anchor, scrollContainer };
+						} else {
+							const pdfPage =
+								document.querySelector("#pdf-container .page") ??
+								document.querySelector("#pdf-container [data-page-number]");
+							const pageRect = pdfPage?.getBoundingClientRect();
+							const top = (selectionRectTop ?? y) - containerRect.top + scrollTop;
+							const left = pageRect
+								? pageRect.right - containerRect.left + scrollLeft + ANNOTATION_CARD_MARGIN_GAP_PX
+								: window.innerWidth * 0.6;
+							pos = { top, left, scrollContainer };
+						}
+					} else {
+						const pdfPage =
+							document.querySelector("#pdf-container .page") ??
+							document.querySelector("#pdf-container [data-page-number]");
+						const pageRect = pdfPage?.getBoundingClientRect();
+						pos = {
+							top: (selectionRectTop ?? y) - containerRect.top + scrollTop,
+							left: pageRect
+								? pageRect.right - containerRect.left + scrollLeft + ANNOTATION_CARD_MARGIN_GAP_PX
+								: window.innerWidth * 0.6,
+							scrollContainer,
+						};
+					}
 
 					if (isHighlightInteraction && activeHighlight?.id) {
 						const hid = activeHighlight.id;

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -207,6 +207,16 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	const [numPages, setNumPages] = useState<number | null>(null);
 	const [showScrollToTop] = useState(false);
 	const [pdfReady, setPdfReady] = useState(false);
+	/** Bumped on PDF.js `pagerendered` so annotation-card restore can retry when page views exist */
+	const [pdfLayoutTick, setPdfLayoutTick] = useState(0);
+	/**
+	 * Bumped once the PDF.js PDFViewer instance is actually ready.
+	 * The library initialises the viewer with a 100ms debounce inside a useLayoutEffect,
+	 * so getViewer() returns null for a short window after pdfReady becomes true.
+	 * Polling after pdfReady ensures both the pagerendered subscriber and the restore
+	 * effect re-run once the viewer is genuinely available.
+	 */
+	const [viewerReadyTick, setViewerReadyTick] = useState(0);
 	const [highlightColor, setHighlightColor] = useState<HighlightColor>("blue");
 
 	// Search hook
@@ -445,26 +455,60 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 
 	// When a new highlight is saved after a text selection annotate, create the pending card
 	useEffect(() => {
-		if (isAnnotating && activeHighlight && pendingAnnotationPos) {
+		if (!addAnnotation) return;
+		const hid = activeHighlight?.id;
+		if (isAnnotating && hid && pendingAnnotationPos) {
 			setAnnotationCards(prev => {
-				const exists = prev.find(c => c.highlightId === activeHighlight.id);
-				return exists ? prev : [...prev, { highlightId: activeHighlight.id, ...pendingAnnotationPos }];
+				const exists = prev.find(c => c.highlightId === hid);
+				return exists ? prev : [...prev, { highlightId: hid, ...pendingAnnotationPos }];
 			});
 			setPendingAnnotationPos(null);
 		}
-	}, [isAnnotating, activeHighlight, pendingAnnotationPos]);
+	}, [addAnnotation, isAnnotating, activeHighlight, pendingAnnotationPos]);
+
+	// Poll for the PDF.js viewer instance becoming available.
+	// The library initialises it with a 100ms debounce, so getViewer() returns null
+	// immediately after pdfReady. We bump viewerReadyTick when it's actually set,
+	// which re-triggers the pagerendered subscriber and the restore effect below.
+	useEffect(() => {
+		if (!pdfReady) return;
+		let timerId: ReturnType<typeof setTimeout>;
+		const check = () => {
+			const viewer = highlighterUtilsRef.current?.getViewer();
+			if (viewer) {
+				setViewerReadyTick(t => t + 1);
+			} else {
+				timerId = setTimeout(check, 50);
+			}
+		};
+		// Start polling slightly after the library's 100ms debounce
+		timerId = setTimeout(check, 120);
+		return () => clearTimeout(timerId);
+	}, [pdfReady]);
+
+	// Re-run restore attempts as each PDF page finishes rendering (page views may be missing before then)
+	useEffect(() => {
+		if (!pdfReady || numPages == null) return;
+		const viewer = highlighterUtilsRef.current?.getViewer();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const bus = (viewer as any)?.eventBus;
+		if (!bus?.on) return;
+		const onPageRendered = () => setPdfLayoutTick((t) => t + 1);
+		bus.on("pagerendered", onPageRendered);
+		return () => bus.off("pagerendered", onPageRendered);
+	}, [pdfReady, numPages, viewerReadyTick]);
 
 	// Restore annotation cards from server-persisted annotations on page load
 	useEffect(() => {
 		if (!pdfReady || hasRestoredRef.current) return;
 
 		const viewer = highlighterUtilsRef.current?.getViewer();
-		const scrollContainer = viewer?.container;
+		const scrollContainer = viewer?.container as HTMLElement | undefined;
 		if (!viewer || !scrollContainer) return;
 
-		// Mark as restored immediately so subsequent annotation saves don't re-trigger this
-		hasRestoredRef.current = true;
-
+		// Wait until both data sources are ready before marking as restored.
+		// Without this guard, if the PDF loads before server data arrives, hasRestoredRef
+		// would be locked to true with empty arrays and the restore would never run.
 		if (!annotations.length || !highlights.length) return;
 
 		// Group annotations by highlight_id, keep the first (earliest) per highlight
@@ -475,23 +519,39 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			}
 		}
 
+		const containerRect = scrollContainer.getBoundingClientRect();
 		const restored: AnnotationCardEntry[] = [];
+		let missingPageView = 0;
+		let attempted = 0;
+
 		byHighlight.forEach(({ content, annotationId }, highlightId) => {
 			const highlight = highlights.find(h => h.id === highlightId);
 			if (!highlight?.position || !highlight.page_number) return;
 
+			attempted++;
+
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 			const pageView = (viewer as any).getPageView(highlight.page_number - 1);
-			if (!pageView?.div || !pageView?.viewport) return;
+			if (!pageView?.div || !pageView?.viewport) {
+				missingPageView += 1;
+				return;
+			}
 
 			const { div: pageDiv, viewport } = pageView;
 			const { boundingRect } = highlight.position;
+			// scaleY converts from stored page-height units to current CSS pixels
 			const scaleY = viewport.height / boundingRect.height;
+
+			// Use getBoundingClientRect so the position is correct regardless of
+			// intermediate offset parents (.pdfViewer vs .PdfHighlighter scroll container).
+			const pageRect = (pageDiv as HTMLElement).getBoundingClientRect();
+			const top = pageRect.top - containerRect.top + scrollContainer.scrollTop + boundingRect.y1 * scaleY;
+			const left = pageRect.right - containerRect.left + 8;
 
 			restored.push({
 				highlightId,
-				top: pageDiv.offsetTop + boundingRect.y1 * scaleY,
-				left: pageDiv.offsetLeft + pageDiv.offsetWidth + 8,
+				top,
+				left,
 				scrollContainer,
 				initialContent: content,
 				annotationId,
@@ -504,7 +564,17 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				return [...prev, ...restored.filter(c => !existing.has(c.highlightId))];
 			});
 		}
-	}, [pdfReady, annotations, highlights]);
+
+		// Lock the ref only when we actually attempted restorations and all page views
+		// were available. If attempted === 0 (no highlights had position data) or
+		// missingPageView > 0, keep retrying on the next pdfLayoutTick.
+		if (attempted > 0 && missingPageView === 0) {
+			hasRestoredRef.current = true;
+		} else if (attempted === 0 && byHighlight.size === 0) {
+			// No annotations to restore at all — nothing to do, lock to stop retrying.
+			hasRestoredRef.current = true;
+		}
+	}, [pdfReady, annotations, highlights, pdfLayoutTick, scale, numPages, viewerReadyTick]);
 
 	// Keep the module-level store in sync so HighlightContainer (in a separate React root) can react
 	useEffect(() => {
@@ -892,7 +962,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	return (
 		<div
 			ref={containerRef}
-			className="flex flex-col w-full h-full overflow-hidden"
+			className="flex flex-col w-full h-full min-h-0 overflow-x-visible overflow-y-hidden"
 			id="pdf-container"
 		>
 			{/* Toolbar */}
@@ -923,8 +993,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				setHighlightColor={setHighlightColor}
 			/>
 
-			{/* PDF Viewer */}
-			<div className="flex-1 overflow-hidden relative">
+			{/* PDF Viewer — overflow-x-visible so margin annotation cards beside the page are not clipped */}
+			<div className="flex-1 min-h-0 overflow-x-visible overflow-y-hidden relative">
 				<PdfLoader
 					key={pdfLoaderKey}
 					document={effectivePdfUrl}
@@ -994,6 +1064,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					removeHighlight={removeHighlight}
 					setUserMessageReferences={setUserMessageReferences}
 			onAnnotate={(y) => {
+					if (!addAnnotation) return;
 					const scrollContainer = highlighterUtilsRef.current?.getViewer()?.container;
 					if (!scrollContainer) return;
 					const containerRect = scrollContainer.getBoundingClientRect();
@@ -1011,11 +1082,12 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					scrollContainer,
 				};
 
-					if (isHighlightInteraction && activeHighlight) {
+					if (isHighlightInteraction && activeHighlight?.id) {
+						const hid = activeHighlight.id;
 						// User clicked an existing highlight — ID is already known, create card immediately
 						setAnnotationCards(prev => {
-							const exists = prev.find(c => c.highlightId === activeHighlight.id);
-							return exists ? prev : [...prev, { highlightId: activeHighlight.id, ...pos }];
+							const exists = prev.find(c => c.highlightId === hid);
+							return exists ? prev : [...prev, { highlightId: hid, ...pos }];
 						});
 					} else {
 						// New text selection — highlight not yet saved; wait for async server response
@@ -1026,7 +1098,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		)}
 
 	{/* Inline Annotation Cards — one per annotated highlight, persists until closed */}
-	{showAnnotationCards && addAnnotation && (() => {
+	{showAnnotationCards && (() => {
 		const FALLBACK_HEIGHT = 120;
 		const GAP = 8;
 		const activeId = activeHighlight?.id;
@@ -1089,19 +1161,22 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 							c.highlightId === card.highlightId ? { ...c, annotationId: savedId } : c
 						))
 					}
-					onDelete={() => {
-						if (card.annotationId && removeAnnotation) removeAnnotation(card.annotationId);
+				onDelete={() => {
+					if (card.annotationId && removeAnnotation) removeAnnotation(card.annotationId);
+					setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
+					setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
+					setIsAnnotating(false);
+					setSelectionRectTop(null);
+				}}
+				onClose={() => {
+					setIsAnnotating(false);
+					setSelectionRectTop(null);
+					// Only remove unsaved cards — saved annotations persist until explicitly deleted
+					if (!card.annotationId) {
 						setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
 						setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
-						setIsAnnotating(false);
-						setSelectionRectTop(null);
-					}}
-					onClose={() => {
-						setIsAnnotating(false);
-						setSelectionRectTop(null);
-						setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
-						setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
-					}}
+					}
+				}}
 				/>,
 				card.scrollContainer
 			)

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -143,6 +143,7 @@ interface PdfHighlighterViewerProps {
 	removeAnnotation?: (annotationId: string) => void;
 	currentUser?: BasicUser | null;
 	showAnnotationCards?: boolean;
+	/** When set (e.g. mobile reader without PaperSidebar), wires the eye toggle on PdfToolbar. */
 	onToggleAnnotationCards?: () => void;
 	/** When true and inline cards are hidden, route annotate flows to the Annotations side panel */
 	annotationsPanelActive?: boolean;

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState, useCallback, useEffect, useMemo } from "react";
+import { useRef, useState, useCallback, useEffect, useMemo, type RefObject } from "react";
 import { createPortal } from "react-dom";
 import {
 	PdfLoader,
@@ -148,6 +148,34 @@ interface PdfHighlighterViewerProps {
 	/** When true and inline cards are hidden, route annotate flows to the Annotations side panel */
 	annotationsPanelActive?: boolean;
 	onAnnotateViaSidePanel?: (payload: { highlightId: string }) => void;
+	/** When true, the side panel is taking horizontal space — left-align PDF pages to make room for margin cards. */
+	sidePanelOpen?: boolean;
+}
+
+/** Syncs PdfLoader's render-prop pdfDocument into parent state without calling setState during render. */
+function PdfDocumentSync({
+	pdfDocument,
+	pdfDocumentRef,
+	setPdfReady,
+	setNumPages,
+}: {
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	pdfDocument: any;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	pdfDocumentRef: RefObject<any>;
+	setPdfReady: (ready: boolean) => void;
+	setNumPages: (n: number) => void;
+}) {
+	useEffect(() => {
+		pdfDocumentRef.current = pdfDocument;
+		setPdfReady(true);
+	}, [pdfDocument, pdfDocumentRef, setPdfReady]);
+
+	useEffect(() => {
+		setNumPages(pdfDocument.numPages);
+	}, [pdfDocument.numPages, setNumPages]);
+
+	return null;
 }
 
 export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
@@ -182,6 +210,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		onToggleAnnotationCards,
 		annotationsPanelActive = false,
 		onAnnotateViaSidePanel,
+		sidePanelOpen = false,
 	} = props;
 
 	// Position anchors for inline annotation cards
@@ -1532,7 +1561,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			<div
 				className={cn(
 					"flex-1 min-h-0 overflow-x-visible overflow-y-hidden relative",
-					pdfHighlightsSuppressedForZoom && "pdf-zoom-layout-pending"
+					pdfHighlightsSuppressedForZoom && "pdf-zoom-layout-pending",
+					showAnnotationCards && sidePanelOpen && "pdf-align-left"
 				)}
 			>
 				<PdfLoader
@@ -1552,37 +1582,33 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					}
 				>
 					{(pdfDocument) => {
-						// Store PDF document ref for text extraction
-						if (pdfDocumentRef.current !== pdfDocument) {
-							pdfDocumentRef.current = pdfDocument;
-							if (!pdfReady) {
-								setPdfReady(true);
-							}
-						}
-						// Set numPages when document loads
-						if (pdfDocument.numPages !== numPages) {
-							setNumPages(pdfDocument.numPages);
-						}
-
 						return (
-							<PdfHighlighter
-								pdfDocument={pdfDocument}
-								pdfScaleValue={scale}
-								highlights={extendedHighlights}
-								onSelection={handleSelection}
-								onCreateGhostHighlight={handleCreateGhostHighlight}
-								onRemoveGhostHighlight={handleRemoveGhostHighlight}
-								enableAreaSelection={(event) => event.altKey}
-								utilsRef={(utils) => {
-									highlighterUtilsRef.current = utils;
-								}}
-								style={{
-									height: "100%",
-								}}
-								textSelectionColor={PDF_TEXT_SELECTION_FILL}
-							>
-								<HighlightContainer onHighlightClick={handleHighlightClick} />
-							</PdfHighlighter>
+							<>
+								<PdfDocumentSync
+									pdfDocument={pdfDocument}
+									pdfDocumentRef={pdfDocumentRef}
+									setPdfReady={setPdfReady}
+									setNumPages={setNumPages}
+								/>
+								<PdfHighlighter
+									pdfDocument={pdfDocument}
+									pdfScaleValue={scale}
+									highlights={extendedHighlights}
+									onSelection={handleSelection}
+									onCreateGhostHighlight={handleCreateGhostHighlight}
+									onRemoveGhostHighlight={handleRemoveGhostHighlight}
+									enableAreaSelection={(event) => event.altKey}
+									utilsRef={(utils) => {
+										highlighterUtilsRef.current = utils;
+									}}
+									style={{
+										height: "100%",
+									}}
+									textSelectionColor={PDF_TEXT_SELECTION_FILL}
+								>
+									<HighlightContainer onHighlightClick={handleHighlightClick} />
+								</PdfHighlighter>
+							</>
 						);
 					}}
 				</PdfLoader>

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState, useCallback, useEffect, useMemo } from "react";
+import { createPortal } from "react-dom";
 import {
 	PdfLoader,
 	PdfHighlighter,
@@ -32,12 +33,15 @@ const HIGHLIGHT_COLOR_MAP: Record<HighlightColor, string> = {
 import EnigmaticLoadingExperience from "@/components/EnigmaticLoadingExperience";
 import { PaperStatus } from "./utils/PdfStatus";
 import InlineAnnotationMenu from "./InlineAnnotationMenu";
+import { InlineAnnotationCard } from "./InlineAnnotationCard";
+import { BasicUser } from "@/lib/auth";
 
 import {
 	ExtendedHighlight,
 	paperHighlightToExtended,
 	extendedToPaperHighlight,
 	HighlightContainer,
+	activeHighlightStore,
 	usePdfSearch,
 	PdfToolbar,
 	findTextPages,
@@ -66,6 +70,7 @@ interface PdfHighlighterViewerProps {
 	setSelectedText: (text: string) => void;
 	tooltipPosition: { x: number; y: number } | null;
 	setTooltipPosition: (position: { x: number; y: number } | null) => void;
+	isAnnotating: boolean;
 	setIsAnnotating: (isAnnotating: boolean) => void;
 	isHighlightInteraction: boolean;
 	setIsHighlightInteraction: (isHighlightInteraction: boolean) => void;
@@ -87,6 +92,8 @@ interface PdfHighlighterViewerProps {
 	setUserMessageReferences: React.Dispatch<React.SetStateAction<string[]>>;
 	onOverlaysCreated?: (positions: Map<string, RenderedHighlightPosition>) => void;
 	onRefreshUrl?: () => Promise<string | null>;
+	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
+	currentUser?: BasicUser | null;
 }
 
 export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
@@ -99,6 +106,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		setSelectedText,
 		tooltipPosition,
 		setTooltipPosition,
+		isAnnotating,
 		setIsAnnotating,
 		isHighlightInteraction,
 		setIsHighlightInteraction,
@@ -111,7 +119,25 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		setUserMessageReferences,
 		onOverlaysCreated,
 		onRefreshUrl,
+		addAnnotation,
+		currentUser,
+		annotations,
 	} = props;
+
+	// Position anchors for inline annotation cards
+	interface AnnotationCardEntry {
+		highlightId: string;
+		top: number;
+		left: number;
+		scrollContainer: Element;
+		initialContent?: string;
+	}
+	const [annotationCards, setAnnotationCards] = useState<AnnotationCardEntry[]>([]);
+	const [selectionRectTop, setSelectionRectTop] = useState<number | null>(null);
+	// Holds position computed during onAnnotate when activeHighlight isn't set yet (new text selection)
+	const [pendingAnnotationPos, setPendingAnnotationPos] = useState<{ top: number; left: number; scrollContainer: Element } | null>(null);
+	// Guard: restore annotation cards from server data only once per mount
+	const hasRestoredRef = useRef(false);
 
 	// Track the effective PDF URL, which may be refreshed on 403 errors
 	const [effectivePdfUrl, setEffectivePdfUrl] = useState(pdfUrl);
@@ -276,6 +302,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					x: rect.right,
 					y: rect.top + rect.height / 2,
 				});
+				setSelectionRectTop(rect.top);
 			}
 		},
 		[setSelectedText, setTooltipPosition, setIsHighlightInteraction]
@@ -324,7 +351,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		(viewportHighlight: ViewportHighlight<ExtendedHighlight>, event: MouseEvent) => {
 			setIsHighlightInteraction(true);
 			setSelectedText(viewportHighlight.content?.text || viewportHighlight.raw_text || "");
-			setTooltipPosition({ x: event.clientX, y: event.clientY });
+			setSelectionRectTop(event.clientY);
 
 			const originalHighlight = extendedHighlights.find(h => h.id === viewportHighlight.id);
 			if (originalHighlight) {
@@ -333,6 +360,17 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				blockScrollOnNextHighlight.current = true;
 				setActiveHighlight(paperHighlight);
 			}
+
+			// If this highlight already has an open annotation card, skip the context menu
+			// and scroll to center the card (at its natural stored position) in the viewport
+			const card = annotationCards.find(c => c.highlightId === viewportHighlight.id);
+			if (!card) {
+				setTooltipPosition({ x: event.clientX, y: event.clientY });
+			} else {
+				const container = card.scrollContainer as HTMLElement;
+				const targetScrollTop = card.top - container.clientHeight / 2;
+				container.scrollTo({ top: Math.max(0, targetScrollTop), behavior: "smooth" });
+			}
 		},
 		[
 			setIsHighlightInteraction,
@@ -340,6 +378,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			setTooltipPosition,
 			setActiveHighlight,
 			extendedHighlights,
+			annotationCards,
 		]
 	);
 
@@ -377,6 +416,73 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		setTooltipPosition,
 		setIsAnnotating,
 	]);
+
+	// When a new highlight is saved after a text selection annotate, create the pending card
+	useEffect(() => {
+		if (isAnnotating && activeHighlight && pendingAnnotationPos) {
+			setAnnotationCards(prev => {
+				const exists = prev.find(c => c.highlightId === activeHighlight.id);
+				return exists ? prev : [...prev, { highlightId: activeHighlight.id, ...pendingAnnotationPos }];
+			});
+			setPendingAnnotationPos(null);
+		}
+	}, [isAnnotating, activeHighlight, pendingAnnotationPos]);
+
+	// Restore annotation cards from server-persisted annotations on page load
+	useEffect(() => {
+		if (!pdfReady || hasRestoredRef.current) return;
+
+		const viewer = highlighterUtilsRef.current?.getViewer();
+		const scrollContainer = viewer?.container;
+		if (!viewer || !scrollContainer) return;
+
+		// Mark as restored immediately so subsequent annotation saves don't re-trigger this
+		hasRestoredRef.current = true;
+
+		if (!annotations.length || !highlights.length) return;
+
+		// Group annotations by highlight_id, keep the first (earliest) per highlight
+		const byHighlight = new Map<string, string>();
+		for (const ann of annotations) {
+			if (!byHighlight.has(ann.highlight_id)) {
+				byHighlight.set(ann.highlight_id, ann.content);
+			}
+		}
+
+		const restored: AnnotationCardEntry[] = [];
+		byHighlight.forEach((content, highlightId) => {
+			const highlight = highlights.find(h => h.id === highlightId);
+			if (!highlight?.position || !highlight.page_number) return;
+
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const pageView = (viewer as any).getPageView(highlight.page_number - 1);
+			if (!pageView?.div || !pageView?.viewport) return;
+
+			const { div: pageDiv, viewport } = pageView;
+			const { boundingRect } = highlight.position;
+			const scaleY = viewport.height / boundingRect.height;
+
+			restored.push({
+				highlightId,
+				top: pageDiv.offsetTop + boundingRect.y1 * scaleY,
+				left: pageDiv.offsetLeft + pageDiv.offsetWidth + 8,
+				scrollContainer,
+				initialContent: content,
+			});
+		});
+
+		if (restored.length > 0) {
+			setAnnotationCards(prev => {
+				const existing = new Set(prev.map(c => c.highlightId));
+				return [...prev, ...restored.filter(c => !existing.has(c.highlightId))];
+			});
+		}
+	}, [pdfReady, annotations, highlights]);
+
+	// Keep the module-level store in sync so HighlightContainer (in a separate React root) can react
+	useEffect(() => {
+		activeHighlightStore.set(activeHighlight?.id);
+	}, [activeHighlight]);
 
 	// Scroll to active highlight when it changes (unless blocked, e.g., when clicking directly on a highlight)
 	useEffect(() => {
@@ -859,8 +965,94 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					addHighlight={handleAddHighlightFromMenu}
 					removeHighlight={removeHighlight}
 					setUserMessageReferences={setUserMessageReferences}
-				/>
-			)}
+			onAnnotate={(y) => {
+					const scrollContainer = highlighterUtilsRef.current?.getViewer()?.container;
+					if (!scrollContainer) return;
+					const containerRect = scrollContainer.getBoundingClientRect();
+					const scrollTop = scrollContainer.scrollTop;
+
+					const pdfPage = document.querySelector('#pdf-container .page')
+						?? document.querySelector('#pdf-container [data-page-number]');
+					const pdfRight = pdfPage
+						? pdfPage.getBoundingClientRect().right + 8
+						: window.innerWidth * 0.6;
+
+					const pos = {
+						top: (selectionRectTop ?? y) - containerRect.top + scrollTop,
+						left: pdfRight - containerRect.left,
+						scrollContainer,
+					};
+
+					if (isHighlightInteraction && activeHighlight) {
+						// User clicked an existing highlight — ID is already known, create card immediately
+						setAnnotationCards(prev => {
+							const exists = prev.find(c => c.highlightId === activeHighlight.id);
+							return exists ? prev : [...prev, { highlightId: activeHighlight.id, ...pos }];
+						});
+					} else {
+						// New text selection — highlight not yet saved; wait for async server response
+						setPendingAnnotationPos(pos);
+					}
+				}}
+			/>
+		)}
+
+	{/* Inline Annotation Cards — one per annotated highlight, persists until closed */}
+	{addAnnotation && (() => {
+		const CARD_HEIGHT = 120;
+		const GAP = 8;
+		const activeId = activeHighlight?.id;
+		const sorted = [...annotationCards].sort((a, b) => a.top - b.top);
+		const activeIdx = sorted.findIndex(c => c.highlightId === activeId);
+
+		let adjusted: typeof sorted;
+		if (activeIdx === -1) {
+			// No active card — standard downward pass
+			let prevBottom = -Infinity;
+			adjusted = sorted.map(card => {
+				const top = Math.max(card.top, prevBottom + GAP);
+				prevBottom = top + CARD_HEIGHT;
+				return { ...card, top };
+			});
+		} else {
+			adjusted = [...sorted];
+			// Active card sits at its exact top
+			// Push cards ABOVE upward so they don't overlap the active card
+			let nextCardTop = sorted[activeIdx].top;
+			for (let i = activeIdx - 1; i >= 0; i--) {
+				const top = Math.min(sorted[i].top, Math.max(0, nextCardTop - GAP - CARD_HEIGHT));
+				adjusted[i] = { ...sorted[i], top };
+				nextCardTop = adjusted[i].top;
+			}
+			// Push cards BELOW downward
+			let prevBottom = sorted[activeIdx].top + CARD_HEIGHT;
+			for (let i = activeIdx + 1; i < sorted.length; i++) {
+				const top = Math.max(sorted[i].top, prevBottom + GAP);
+				adjusted[i] = { ...sorted[i], top };
+				prevBottom = adjusted[i].top + CARD_HEIGHT;
+			}
+		}
+		return adjusted.map(card =>
+			createPortal(
+				<InlineAnnotationCard
+					key={card.highlightId}
+					highlightId={card.highlightId}
+					topPosition={card.top}
+					leftPosition={card.left}
+					initialContent={card.initialContent}
+					isActive={card.highlightId === activeId}
+					user={currentUser ?? null}
+					addAnnotation={addAnnotation}
+					onClose={() => {
+						setIsAnnotating(false);
+						setSelectionRectTop(null);
+						setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
+					}}
+				/>,
+				card.scrollContainer
+			)
+		);
+	})()}
 
 			{/* Scroll to top button */}
 			{showScrollToTop && (

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -1,14 +1,6 @@
 "use client";
 
-import {
-	useRef,
-	useState,
-	useCallback,
-	useEffect,
-	useMemo,
-	type Dispatch,
-	type SetStateAction,
-} from "react";
+import { useRef, useState, useCallback, useEffect, useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
 	PdfLoader,
@@ -49,6 +41,7 @@ import {
 	createTextHighlightOverlays,
 	getAssistantHighlightBackgroundRgba,
 	getUserHighlightBackgroundRgba,
+	PDF_TEXT_SELECTION_FILL,
 } from "./pdf-viewer";
 
 // Re-export types for external use
@@ -154,11 +147,6 @@ interface PdfHighlighterViewerProps {
 	/** When true and inline cards are hidden, route annotate flows to the Annotations side panel */
 	annotationsPanelActive?: boolean;
 	onAnnotateViaSidePanel?: (payload: { highlightId: string }) => void;
-	/** Controlled highlight color (optional; defaults to internal state). */
-	highlightColor?: HighlightColor;
-	setHighlightColor?: Dispatch<SetStateAction<HighlightColor>>;
-	/** When false, color + annotation visibility live on PaperSidebar (desktop). Default true. */
-	showToolbarColorAndEye?: boolean;
 }
 
 export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
@@ -193,9 +181,6 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		onToggleAnnotationCards,
 		annotationsPanelActive = false,
 		onAnnotateViaSidePanel,
-		highlightColor: highlightColorProp,
-		setHighlightColor: setHighlightColorProp,
-		showToolbarColorAndEye = true,
 	} = props;
 
 	// Position anchors for inline annotation cards
@@ -290,9 +275,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	 * effect re-run once the viewer is genuinely available.
 	 */
 	const [viewerReadyTick, setViewerReadyTick] = useState(0);
-	const [internalHighlightColor, setInternalHighlightColor] = useState<HighlightColor>("blue");
-	const highlightColor = highlightColorProp ?? internalHighlightColor;
-	const setHighlightColor = setHighlightColorProp ?? setInternalHighlightColor;
+	const [highlightColor, setHighlightColor] = useState<HighlightColor>("blue");
 
 	// Search hook
 	const search = usePdfSearch({
@@ -687,6 +670,12 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				return;
 			}
 
+			// Annotations side panel open: scroll list via activeHighlight only — no peek card or inline menu
+			if (annotationsPanelActive && hasPersisted) {
+				setPeekAnnotationCardHighlightId(null);
+				return;
+			}
+
 			// Inline cards hidden: peek persisted thread when we can anchor a margin card
 			if (hasPersisted) {
 				const ph = originalHighlight
@@ -727,6 +716,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			extendedHighlights,
 			annotationCards,
 			showAnnotationCards,
+			annotationsPanelActive,
 			highlightHasPersistedAnnotations,
 			ensureAnnotationCardEntry,
 			highlights,
@@ -1285,6 +1275,15 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 						if (
 							hid &&
 							!showAnnotationCards &&
+							annotationsPanelActive &&
+							highlightHasPersistedAnnotations(hid)
+						) {
+							setPeekAnnotationCardHighlightId(null);
+							return;
+						}
+						if (
+							hid &&
+							!showAnnotationCards &&
 							highlightHasPersistedAnnotations(hid) &&
 							highlight.position &&
 							highlight.page_number
@@ -1459,6 +1458,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		onOverlaysCreated,
 		activeHighlight,
 		showAnnotationCards,
+		annotationsPanelActive,
 		highlightHasPersistedAnnotations,
 		ensureAnnotationCardEntry,
 	]);
@@ -1497,7 +1497,6 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				setHighlightColor={setHighlightColor}
 				showAnnotationCards={showAnnotationCards}
 				onToggleAnnotationCards={onToggleAnnotationCards}
-				showColorAndEye={showToolbarColorAndEye}
 			/>
 
 			{/* PDF Viewer — overflow-x-visible so margin annotation cards beside the page are not clipped */}
@@ -1551,7 +1550,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 								style={{
 									height: "100%",
 								}}
-								textSelectionColor="rgba(59, 130, 246, 0.3)"
+								textSelectionColor={PDF_TEXT_SELECTION_FILL}
 							>
 								<HighlightContainer onHighlightClick={handleHighlightClick} />
 							</PdfHighlighter>
@@ -1712,11 +1711,13 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 							return next;
 						})
 					}
-					onAnnotationSaved={(savedId) =>
+					onAnnotationSaved={(_savedId) => {
 						setAnnotationCards(prev => prev.map(c =>
-							c.highlightId === card.highlightId ? { ...c, annotationId: savedId } : c
-						))
-					}
+							c.highlightId === card.highlightId ? { ...c, annotationId: _savedId } : c
+						));
+						// Match side-panel compose: drop PDF "active" tint after first note is saved
+						setActiveHighlight(null);
+					}}
 					onClose={() => {
 						setIsAnnotating(false);
 						setSelectionRectTop(null);
@@ -1725,6 +1726,16 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 						}
 						// Only remove unsaved cards — saved annotation threads persist until all comments are deleted
 						if (!card.annotationId) {
+							const hasAnn = annotations.some((a) => a.highlight_id === card.highlightId);
+							if (!hasAnn) {
+								const h = highlights.find((x) => x.id === card.highlightId);
+								if (h) {
+									removeHighlight(h);
+									if (activeHighlight?.id === card.highlightId) {
+										setActiveHighlight(null);
+									}
+								}
+							}
 							setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
 							setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
 						}

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -94,6 +94,7 @@ interface PdfHighlighterViewerProps {
 	onRefreshUrl?: () => Promise<string | null>;
 	addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
 	currentUser?: BasicUser | null;
+	showAnnotationCards?: boolean;
 }
 
 export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
@@ -122,6 +123,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		addAnnotation,
 		currentUser,
 		annotations,
+		showAnnotationCards = true,
 	} = props;
 
 	// Position anchors for inline annotation cards
@@ -998,7 +1000,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		)}
 
 	{/* Inline Annotation Cards — one per annotated highlight, persists until closed */}
-	{addAnnotation && (() => {
+	{showAnnotationCards && addAnnotation && (() => {
 		const CARD_HEIGHT = 120;
 		const GAP = 8;
 		const activeId = activeHighlight?.id;

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -97,6 +97,7 @@ interface PdfHighlighterViewerProps {
 	removeAnnotation?: (annotationId: string) => void;
 	currentUser?: BasicUser | null;
 	showAnnotationCards?: boolean;
+	onToggleAnnotationCards?: () => void;
 }
 
 export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
@@ -128,6 +129,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		currentUser,
 		annotations,
 		showAnnotationCards = true,
+		onToggleAnnotationCards,
 	} = props;
 
 	// Position anchors for inline annotation cards
@@ -991,6 +993,8 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				handleStatusChange={handleStatusChange}
 				highlightColor={highlightColor}
 				setHighlightColor={setHighlightColor}
+				showAnnotationCards={showAnnotationCards}
+				onToggleAnnotationCards={onToggleAnnotationCards}
 			/>
 
 			{/* PDF Viewer — overflow-x-visible so margin annotation cards beside the page are not clipped */}

--- a/client/src/components/PdfHighlighterViewer.tsx
+++ b/client/src/components/PdfHighlighterViewer.tsx
@@ -14,6 +14,7 @@ import type {
 } from "react-pdf-highlighter-extended";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { ChevronUp } from "lucide-react";
 import {
 	PaperHighlight,
@@ -22,14 +23,6 @@ import {
 	HighlightColor,
 } from "@/lib/schema";
 
-// Map highlight color names to rgba values (shared with HighlightContainer)
-const HIGHLIGHT_COLOR_MAP: Record<HighlightColor, string> = {
-	yellow: "rgba(255, 235, 59, 0.4)",
-	green: "rgba(76, 175, 80, 0.4)",
-	blue: "rgba(66, 165, 245, 0.4)",
-	pink: "rgba(236, 64, 122, 0.4)",
-	purple: "rgba(171, 71, 188, 0.4)",
-};
 import EnigmaticLoadingExperience from "@/components/EnigmaticLoadingExperience";
 import { PaperStatus } from "./utils/PdfStatus";
 import InlineAnnotationMenu from "./InlineAnnotationMenu";
@@ -46,6 +39,8 @@ import {
 	PdfToolbar,
 	findTextPages,
 	createTextHighlightOverlays,
+	getAssistantHighlightBackgroundRgba,
+	getUserHighlightBackgroundRgba,
 } from "./pdf-viewer";
 
 // Re-export types for external use
@@ -188,7 +183,6 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		top: number;
 		left: number;
 		scrollContainer: Element;
-		initialContent?: string;
 		annotationId?: string;
 	}
 	const [annotationCards, setAnnotationCards] = useState<AnnotationCardEntry[]>([]);
@@ -292,13 +286,83 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		[highlights]
 	);
 
+	/**
+	 * Highlight rectangles (react-pdf-highlighter-extended) are re-laid out from scaled positions on
+	 * every scroll/textlayerrender. During zoom, PDF.js fires many pagerendereds and ResizeObserver
+	 * updates — rects jump frame-to-frame (flashy). We hide the highlight layer until layout quiets.
+	 */
+	const [pdfHighlightsSuppressedForZoom, setPdfHighlightsSuppressedForZoom] = useState(false);
+	const pendingZoomHighlightRef = useRef(false);
+	const zoomHighlightDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	/** Bumped on each zoom press / safety timeout so in-flight rAF scroll checks don't unsuppress for a stale zoom. */
+	const zoomHighlightSessionRef = useRef(0);
+	const ZOOM_HIGHLIGHT_DEBOUNCE_MS = 300;
+	const ZOOM_SCROLL_STABLE_MAX_FRAMES = 45;
+	/** Consecutive rAF frames with matching scrollTop before we trust scroll has settled. */
+	const ZOOM_SCROLL_STABLE_MATCHES_NEEDED = 2;
+
+	/** Wait until scrollTop matches across several rAF samples (PDF.js can nudge scroll for multiple frames). */
+	const finishZoomWhenScrollStable = useCallback((session: number) => {
+		let prevScroll: number | undefined;
+		let stableMatches = 0;
+		let framesLeft = ZOOM_SCROLL_STABLE_MAX_FRAMES;
+		const unsuppressAfterPaint = () => {
+			requestAnimationFrame(() => {
+				requestAnimationFrame(() => {
+					requestAnimationFrame(() => {
+						if (session !== zoomHighlightSessionRef.current || !pendingZoomHighlightRef.current) return;
+						pendingZoomHighlightRef.current = false;
+						setPdfHighlightsSuppressedForZoom(false);
+					});
+				});
+			});
+		};
+		const tick = () => {
+			requestAnimationFrame(() => {
+				if (session !== zoomHighlightSessionRef.current || !pendingZoomHighlightRef.current) return;
+				const el = highlighterUtilsRef.current?.getViewer()?.container as HTMLElement | undefined;
+				const cur = el?.scrollTop ?? 0;
+				if (prevScroll !== undefined && Math.abs(cur - prevScroll) < 0.5) {
+					stableMatches += 1;
+					if (stableMatches >= ZOOM_SCROLL_STABLE_MATCHES_NEEDED) {
+						unsuppressAfterPaint();
+						return;
+					}
+				} else {
+					stableMatches = 0;
+				}
+				prevScroll = cur;
+				if (--framesLeft <= 0) {
+					unsuppressAfterPaint();
+					return;
+				}
+				tick();
+			});
+		};
+		tick();
+	}, []);
+
 	// Zoom controls
 	const zoomIn = useCallback(() => {
+		if (zoomHighlightDebounceRef.current) {
+			clearTimeout(zoomHighlightDebounceRef.current);
+			zoomHighlightDebounceRef.current = null;
+		}
+		zoomHighlightSessionRef.current += 1;
 		setScale((prev) => Math.min(prev + 0.25, 3));
+		pendingZoomHighlightRef.current = true;
+		setPdfHighlightsSuppressedForZoom(true);
 	}, []);
 
 	const zoomOut = useCallback(() => {
+		if (zoomHighlightDebounceRef.current) {
+			clearTimeout(zoomHighlightDebounceRef.current);
+			zoomHighlightDebounceRef.current = null;
+		}
+		zoomHighlightSessionRef.current += 1;
 		setScale((prev) => Math.max(prev - 0.25, 0.5));
+		pendingZoomHighlightRef.current = true;
+		setPdfHighlightsSuppressedForZoom(true);
 	}, []);
 
 	// Apply scale changes directly to the viewer
@@ -306,10 +370,67 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 	useEffect(() => {
 		scaleRef.current = scale;
 		const viewer = highlighterUtilsRef.current?.getViewer();
-		if (viewer) {
-			viewer.currentScaleValue = String(scale);
+		if (!viewer) return;
+		viewer.currentScaleValue = String(scale);
+
+		// Guard the currentScaleValue setter against the library's stale ResizeObserver.
+		// The library's useLayoutEffect captures pdfScaleValue at the time [highlights, selectionTip,
+		// onSelectionFinished] last changed — NOT when pdfScaleValue changes — so its ResizeObserver
+		// calls handleScaleValue() with an old scale value on every container resize (e.g., when a
+		// horizontal scrollbar appears at 1.25× that wasn't present at 1.0×). This triggers a
+		// 1.25→1→1.25 scale sequence in PDF.js, causing 3+ extra page canvas redraws that visually
+		// flash the PDF content. Block any scale reversion while zoom animation is in progress.
+		let proto: object | null = Object.getPrototypeOf(viewer);
+		let originalDescriptor: PropertyDescriptor | undefined;
+		while (proto) {
+			originalDescriptor = Object.getOwnPropertyDescriptor(proto, 'currentScaleValue');
+			if (originalDescriptor?.set) break;
+			proto = Object.getPrototypeOf(proto);
 		}
+		const originalSet = originalDescriptor?.set;
+		if (!originalSet) return;
+
+		Object.defineProperty(viewer as object, 'currentScaleValue', {
+			get: originalDescriptor!.get,
+			set(value: string) {
+				// During zoom animation, block any setter call that would revert to an old scale
+				if (pendingZoomHighlightRef.current) {
+					const num = parseFloat(value);
+					if (!isNaN(num) && Math.abs(num - scaleRef.current) > 0.001) {
+						return;
+					}
+				}
+				originalSet.call(this, value);
+			},
+			configurable: true,
+		});
+
+		return () => {
+			// Remove the instance-level override so the prototype setter is used again.
+			// The new effect run will re-install it with the updated scale.
+			try {
+				// eslint-disable-next-line @typescript-eslint/no-explicit-any
+				delete (viewer as any).currentScaleValue;
+			} catch {
+				// ignore
+			}
+		};
 	}, [scale]);
+
+	// Safety: never leave highlight overlays suppressed if pagerendered never settles.
+	useEffect(() => {
+		if (!pdfHighlightsSuppressedForZoom) return;
+		const id = setTimeout(() => {
+			if (zoomHighlightDebounceRef.current) {
+				clearTimeout(zoomHighlightDebounceRef.current);
+				zoomHighlightDebounceRef.current = null;
+			}
+			zoomHighlightSessionRef.current += 1;
+			pendingZoomHighlightRef.current = false;
+			setPdfHighlightsSuppressedForZoom(false);
+		}, 3000);
+		return () => clearTimeout(id);
+	}, [pdfHighlightsSuppressedForZoom]);
 
 	// Re-apply scale after container resizes to override the library's stale ResizeObserver
 	// (the library's ResizeObserver captures a stale pdfScaleValue due to missing dependency)
@@ -383,6 +504,16 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			return changed ? next : prev;
 		});
 	}, [highlights]);
+
+	/** Coalesce all layout-driven syncs to at most one per animation frame (avoids burst updates when pagerendered + ResizeObserver + scroll fire together). */
+	const annotationCardSyncRafRef = useRef(0);
+	const scheduleAnnotationCardSync = useCallback(() => {
+		if (annotationCardSyncRafRef.current !== 0) return;
+		annotationCardSyncRafRef.current = requestAnimationFrame(() => {
+			annotationCardSyncRafRef.current = 0;
+			syncAnnotationCardPositions();
+		});
+	}, [syncAnnotationCardPositions]);
 
 	// Handle selection
 	const handleSelection = useCallback(
@@ -532,6 +663,26 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		setIsAnnotating,
 	]);
 
+	// Click outside the inline annotation card (and outside highlight / sidebar rows) clears active highlight
+	useEffect(() => {
+		if (!activeHighlight) return;
+
+		const handleDocumentMouseDown = (e: MouseEvent) => {
+			const target = e.target as HTMLElement | null;
+			if (!target) return;
+
+			if (target.closest("[data-inline-annotation-card]")) return;
+			if (target.closest(".TextHighlight__parts, .TextHighlight__part")) return;
+			if (target.closest("[data-annotation-sidebar-row]")) return;
+			if (target.closest("[data-inline-annotation-menu]")) return;
+
+			setActiveHighlight(null);
+		};
+
+		document.addEventListener("mousedown", handleDocumentMouseDown);
+		return () => document.removeEventListener("mousedown", handleDocumentMouseDown);
+	}, [activeHighlight, setActiveHighlight]);
+
 	// When a new highlight is saved after a text selection annotate, create the pending card
 	useEffect(() => {
 		if (!addAnnotation) return;
@@ -572,10 +723,28 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const bus = (viewer as any)?.eventBus;
 		if (!bus?.on) return;
-		const onPageRendered = () => setPdfLayoutTick((t) => t + 1);
+		const onPageRendered = () => {
+			setPdfLayoutTick((t) => t + 1);
+			if (!pendingZoomHighlightRef.current) return;
+			if (zoomHighlightDebounceRef.current) {
+				clearTimeout(zoomHighlightDebounceRef.current);
+			}
+			zoomHighlightDebounceRef.current = setTimeout(() => {
+				zoomHighlightDebounceRef.current = null;
+				if (!pendingZoomHighlightRef.current) return;
+				const session = zoomHighlightSessionRef.current;
+				finishZoomWhenScrollStable(session);
+			}, ZOOM_HIGHLIGHT_DEBOUNCE_MS);
+		};
 		bus.on("pagerendered", onPageRendered);
-		return () => bus.off("pagerendered", onPageRendered);
-	}, [pdfReady, numPages, viewerReadyTick]);
+		return () => {
+			bus.off("pagerendered", onPageRendered);
+			if (zoomHighlightDebounceRef.current) {
+				clearTimeout(zoomHighlightDebounceRef.current);
+				zoomHighlightDebounceRef.current = null;
+			}
+		};
+	}, [pdfReady, numPages, viewerReadyTick, finishZoomWhenScrollStable]);
 
 	// Reset the restore guard whenever the set of persisted annotation IDs changes (e.g.
 	// after an annotation is created or deleted on the server). This ensures that if the
@@ -603,11 +772,11 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		// would be locked to true with empty arrays and the restore would never run.
 		if (!annotations.length || !highlights.length) return;
 
-		// Group annotations by highlight_id, keep the first (earliest) per highlight
-		const byHighlight = new Map<string, { content: string; annotationId: string }>();
+		// Group annotations by highlight_id, keep the first (earliest) annotationId per highlight
+		const byHighlight = new Map<string, string>();
 		for (const ann of annotations) {
 			if (!byHighlight.has(ann.highlight_id)) {
-				byHighlight.set(ann.highlight_id, { content: ann.content, annotationId: ann.id });
+				byHighlight.set(ann.highlight_id, ann.id);
 			}
 		}
 
@@ -615,7 +784,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		let missingPageView = 0;
 		let attempted = 0;
 
-		byHighlight.forEach(({ content, annotationId }, highlightId) => {
+		byHighlight.forEach((annotationId, highlightId) => {
 			const highlight = highlights.find(h => h.id === highlightId);
 			if (!highlight?.position || !highlight.page_number) return;
 
@@ -632,7 +801,6 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				top: anchor.top,
 				left: anchor.left,
 				scrollContainer,
-				initialContent: content,
 				annotationId,
 			});
 		});
@@ -655,16 +823,24 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		}
 	}, [pdfReady, annotations, highlights, pdfLayoutTick, scale, numPages, viewerReadyTick]);
 
+	// Auto-remove card entries whose entire annotation thread has been deleted
+	useEffect(() => {
+		setAnnotationCards(prev => prev.filter(card =>
+			!card.annotationId ||
+			annotations.some(a => a.highlight_id === card.highlightId)
+		));
+	}, [annotations]);
+
 	// Keep margin card anchors in sync when zoom/layout changes (restore only sets initial positions once).
 	useEffect(() => {
 		if (!pdfReady) return;
-		syncAnnotationCardPositions();
+		scheduleAnnotationCardSync();
 	}, [
 		pdfReady,
 		pdfLayoutTick,
 		viewerReadyTick,
 		annotationCards.length,
-		syncAnnotationCardPositions,
+		scheduleAnnotationCardSync,
 	]);
 
 	// PDF scroll/resize does not trigger React state — re-sync card positions from live page geometry.
@@ -674,16 +850,11 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 		const el = viewer?.container as HTMLElement | undefined;
 		if (!el) return;
 
-		let rafId = 0;
-		const scheduleSync = () => {
-			if (rafId !== 0) return;
-			rafId = requestAnimationFrame(() => {
-				rafId = 0;
-				syncAnnotationCardPositions();
-			});
+		const onScrollOrResize = () => {
+			scheduleAnnotationCardSync();
 		};
 
-		el.addEventListener("scroll", scheduleSync, { passive: true });
+		el.addEventListener("scroll", onScrollOrResize, { passive: true });
 		const ro = new ResizeObserver(() => {
 			// Re-apply correct scale synchronously before browser can paint.
 			// Our callback fires after the library's (registered earlier), so the library's stale
@@ -693,18 +864,21 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			if (v && v.currentScaleValue !== String(scaleRef.current)) {
 				v.currentScaleValue = String(scaleRef.current);
 			}
-			scheduleSync();
+			scheduleAnnotationCardSync();
 		});
 		ro.observe(el);
-		window.addEventListener("resize", scheduleSync);
+		window.addEventListener("resize", onScrollOrResize);
 
 		return () => {
-			el.removeEventListener("scroll", scheduleSync);
+			el.removeEventListener("scroll", onScrollOrResize);
 			ro.disconnect();
-			window.removeEventListener("resize", scheduleSync);
-			if (rafId !== 0) cancelAnimationFrame(rafId);
+			window.removeEventListener("resize", onScrollOrResize);
+			if (annotationCardSyncRafRef.current !== 0) {
+				cancelAnimationFrame(annotationCardSyncRafRef.current);
+				annotationCardSyncRafRef.current = 0;
+			}
 		};
-	}, [pdfReady, viewerReadyTick, syncAnnotationCardPositions]);
+	}, [pdfReady, viewerReadyTick, scheduleAnnotationCardSync]);
 
 	// Keep the module-level store in sync so HighlightContainer (in a separate React root) can react
 	useEffect(() => {
@@ -909,10 +1083,12 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 				);
 				if (existingOverlay) continue;
 
-				// Use different colors based on role and user's color selection
-				const backgroundColor = highlight.role === "assistant"
-					? "rgba(168, 85, 247, 0.3)"  // Purple for assistant
-					: HIGHLIGHT_COLOR_MAP[highlight.color || "blue"]; // User's selected color
+				const overlayIsActive =
+					Boolean(highlight.id) && highlight.id === activeHighlight?.id;
+				const backgroundColor =
+					highlight.role === "assistant"
+						? getAssistantHighlightBackgroundRgba(overlayIsActive)
+						: getUserHighlightBackgroundRgba(highlight.color, overlayIsActive);
 
 				const overlays = createTextHighlightOverlays(
 					textLayer,
@@ -1087,7 +1263,7 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			pendingTimeouts.forEach((timeout) => clearTimeout(timeout));
 			pendingTimeouts.clear();
 		};
-	}, [pdfReady, highlights, scale, onOverlaysCreated]);
+	}, [pdfReady, highlights, scale, onOverlaysCreated, activeHighlight]);
 
 	return (
 		<div
@@ -1126,7 +1302,12 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 			/>
 
 			{/* PDF Viewer — overflow-x-visible so margin annotation cards beside the page are not clipped */}
-			<div className="flex-1 min-h-0 overflow-x-visible overflow-y-hidden relative">
+			<div
+				className={cn(
+					"flex-1 min-h-0 overflow-x-visible overflow-y-hidden relative",
+					pdfHighlightsSuppressedForZoom && "pdf-zoom-layout-pending"
+				)}
+			>
 				<PdfLoader
 					key={pdfLoaderKey}
 					document={effectivePdfUrl}
@@ -1301,13 +1482,13 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 					highlightId={card.highlightId}
 					topPosition={card.top}
 					leftPosition={card.left}
-					initialContent={card.initialContent}
-					annotationId={card.annotationId}
+					annotations={annotations.filter(a => a.highlight_id === card.highlightId)}
 					isActive={card.highlightId === activeId}
 					user={currentUser ?? null}
-				addAnnotation={addAnnotation}
-				updateAnnotation={updateAnnotation}
-				onHeightChange={(h) =>
+					addAnnotation={addAnnotation}
+					updateAnnotation={updateAnnotation}
+					removeAnnotation={removeAnnotation}
+					onHeightChange={(h) =>
 						setCardHeights(prev => {
 							const next = new Map(prev);
 							next.set(card.highlightId, h);
@@ -1319,22 +1500,24 @@ export function PdfHighlighterViewer(props: PdfHighlighterViewerProps) {
 							c.highlightId === card.highlightId ? { ...c, annotationId: savedId } : c
 						))
 					}
-				onDelete={() => {
-					if (card.annotationId && removeAnnotation) removeAnnotation(card.annotationId);
-					setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
-					setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
-					setIsAnnotating(false);
-					setSelectionRectTop(null);
-				}}
-				onClose={() => {
-					setIsAnnotating(false);
-					setSelectionRectTop(null);
-					// Only remove unsaved cards — saved annotations persist until explicitly deleted
-					if (!card.annotationId) {
-						setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
-						setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
-					}
-				}}
+					onClose={() => {
+						setIsAnnotating(false);
+						setSelectionRectTop(null);
+						// Only remove unsaved cards — saved annotation threads persist until all comments are deleted
+						if (!card.annotationId) {
+							setAnnotationCards(prev => prev.filter(c => c.highlightId !== card.highlightId));
+							setCardHeights(prev => { const next = new Map(prev); next.delete(card.highlightId); return next; });
+						}
+					}}
+					onCardFocus={() => {
+						const h = highlights.find(x => x.id === card.highlightId);
+						if (h) {
+							blockScrollOnNextHighlight.current = true;
+							setActiveHighlight(h);
+							setIsHighlightInteraction(true);
+							setSelectedText(h.raw_text ?? "");
+						}
+					}}
 				/>,
 				card.scrollContainer
 			)

--- a/client/src/components/ProjectPaperPreview.tsx
+++ b/client/src/components/ProjectPaperPreview.tsx
@@ -128,6 +128,7 @@ export function ProjectPaperPreview({ paper, projectId }: ProjectPaperPreviewPro
                             setSelectedText={() => { }}
                             tooltipPosition={null}
                             setTooltipPosition={() => { }}
+                            isAnnotating={false}
                             setIsAnnotating={() => { }}
                             isHighlightInteraction={false}
                             setIsHighlightInteraction={() => { }}

--- a/client/src/components/RichAudioOverview.tsx
+++ b/client/src/components/RichAudioOverview.tsx
@@ -221,6 +221,7 @@ export const RichAudioOverview = ({
                                 setUserMessageReferences={() => { }}
                                 setSelectedText={() => { }}
                                 setTooltipPosition={() => { }}
+                                isAnnotating={false}
                                 setIsAnnotating={() => { }}
                                 setIsHighlightInteraction={() => { }}
                                 isHighlightInteraction={false}

--- a/client/src/components/SidePanelContent.tsx
+++ b/client/src/components/SidePanelContent.tsx
@@ -774,7 +774,7 @@ export function SidePanelContent({
         <>
             {
                 rightSideFunction !== 'Focus' && (
-                    <div className="flex-grow h-full overflow-hidden">
+                    <div className="flex-grow h-full overflow-hidden pr-[60px]">
                         {
                             rightSideFunction === 'Annotations' && user && (
                                 <div className={`flex flex-col ${heightClass} overflow-y-auto`}>

--- a/client/src/components/SidePanelContent.tsx
+++ b/client/src/components/SidePanelContent.tsx
@@ -60,10 +60,7 @@ interface SidePanelContentProps {
     annotations: PaperHighlightAnnotation[];
     highlights: PaperHighlight[];
     handleHighlightClick: (highlight: PaperHighlight) => void;
-    addAnnotation: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
     activeHighlight: PaperHighlight | null;
-    updateAnnotation: (annotationId: string, text: string) => void;
-    removeAnnotation: (annotationId: string) => void;
     isSharing: boolean;
     handleShare: () => void;
     handleUnshare: () => void;
@@ -94,10 +91,7 @@ export function SidePanelContent({
     annotations,
     highlights,
     handleHighlightClick,
-    addAnnotation,
     activeHighlight,
-    updateAnnotation,
-    removeAnnotation,
     isSharing,
     handleShare,
     handleUnshare,
@@ -783,10 +777,7 @@ export function SidePanelContent({
                                         highlights={highlights}
                                         user={user}
                                         onHighlightClick={handleHighlightClick}
-                                        addAnnotation={addAnnotation}
                                         activeHighlight={activeHighlight}
-                                        updateAnnotation={updateAnnotation}
-                                        removeAnnotation={removeAnnotation}
                                         renderedHighlightPositions={renderedHighlightPositions}
                                     />
                                 </div>

--- a/client/src/components/SidePanelContent.tsx
+++ b/client/src/components/SidePanelContent.tsx
@@ -75,7 +75,7 @@ interface SidePanelContentProps {
     isMobile: boolean;
     renderedHighlightPositions?: Map<string, RenderedHighlightPosition>;
     composeHighlightId?: string | null;
-    onComposeHighlightDismiss?: () => void;
+    onComposeHighlightDismiss?: (cancelledHighlightId?: string | null) => void;
     addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
 }
 

--- a/client/src/components/SidePanelContent.tsx
+++ b/client/src/components/SidePanelContent.tsx
@@ -74,6 +74,9 @@ interface SidePanelContentProps {
     setUserMessageReferences: React.Dispatch<React.SetStateAction<string[]>>;
     isMobile: boolean;
     renderedHighlightPositions?: Map<string, RenderedHighlightPosition>;
+    composeHighlightId?: string | null;
+    onComposeHighlightDismiss?: () => void;
+    addAnnotation?: (highlightId: string, content: string) => Promise<PaperHighlightAnnotation>;
 }
 
 interface ChatRequestBody {
@@ -105,6 +108,9 @@ export function SidePanelContent({
     setUserMessageReferences,
     isMobile,
     renderedHighlightPositions,
+    composeHighlightId,
+    onComposeHighlightDismiss,
+    addAnnotation,
 }: SidePanelContentProps) {
     const { user } = useAuth();
     const [conversationId, setConversationId] = useState<string | null>(null);
@@ -779,6 +785,9 @@ export function SidePanelContent({
                                         onHighlightClick={handleHighlightClick}
                                         activeHighlight={activeHighlight}
                                         renderedHighlightPositions={renderedHighlightPositions}
+                                        composeHighlightId={composeHighlightId}
+                                        onComposeHighlightDismiss={onComposeHighlightDismiss}
+                                        addAnnotation={addAnnotation}
                                     />
                                 </div>
                             )

--- a/client/src/components/SidePanelContent.tsx
+++ b/client/src/components/SidePanelContent.tsx
@@ -773,7 +773,7 @@ export function SidePanelContent({
     return (
         <>
             {
-                rightSideFunction !== 'Focus' && (
+                rightSideFunction !== 'Read' && (
                     <div className="flex-grow h-full overflow-hidden pr-[60px]">
                         {
                             rightSideFunction === 'Annotations' && user && (

--- a/client/src/components/pdf-viewer/HighlightContainer.tsx
+++ b/client/src/components/pdf-viewer/HighlightContainer.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { HighlightColor } from "@/lib/schema";
 import { useEffect, useState } from "react";
 import type { ViewportHighlight } from "react-pdf-highlighter-extended";
 import {
@@ -9,17 +8,11 @@ import {
 	useHighlightContainerContext,
 } from "react-pdf-highlighter-extended";
 import { activeHighlightStore } from "./activeHighlightStore";
+import {
+	getAssistantHighlightBackgroundRgba,
+	getUserHighlightBackgroundRgba,
+} from "./highlightColors";
 import { ExtendedHighlight } from "./types";
-
-// Map highlight color names to rgba values: [inactive, active]
-// Inactive uses low opacity; active uses the original "normal" color
-const HIGHLIGHT_COLOR_MAP: Record<HighlightColor, [string, string]> = {
-	yellow: ["rgba(255, 235, 59, 0.1)",  "rgba(255, 235, 59, 0.4)"],
-	green:  ["rgba(76, 175, 80, 0.1)",   "rgba(76, 175, 80, 0.4)"],
-	blue:   ["rgba(66, 165, 245, 0.1)",  "rgba(66, 165, 245, 0.4)"],
-	pink:   ["rgba(236, 64, 122, 0.1)",  "rgba(236, 64, 122, 0.4)"],
-	purple: ["rgba(171, 71, 188, 0.1)",  "rgba(171, 71, 188, 0.4)"],
-};
 
 interface HighlightContainerProps {
 	onHighlightClick: (highlight: ViewportHighlight<ExtendedHighlight>, event: MouseEvent) => void;
@@ -45,8 +38,8 @@ export function HighlightContainer({ onHighlightClick }: HighlightContainerProps
 	// Inactive highlights are dimmed; active highlight uses the original normal color
 	const highlightColor =
 		highlight.role === "assistant"
-			? isActive ? "rgba(168, 85, 247, 0.3)" : "rgba(168, 85, 247, 0.15)"
-			: HIGHLIGHT_COLOR_MAP[highlight.color || "blue"][isActive ? 1 : 0];
+			? getAssistantHighlightBackgroundRgba(isActive)
+			: getUserHighlightBackgroundRgba(highlight.color, isActive);
 
 	if (isTextHighlight) {
 		return (

--- a/client/src/components/pdf-viewer/HighlightContainer.tsx
+++ b/client/src/components/pdf-viewer/HighlightContainer.tsx
@@ -1,21 +1,24 @@
 "use client";
 
+import { HighlightColor } from "@/lib/schema";
+import { useEffect, useState } from "react";
+import type { ViewportHighlight } from "react-pdf-highlighter-extended";
 import {
-	TextHighlight,
 	AreaHighlight,
+	TextHighlight,
 	useHighlightContainerContext,
 } from "react-pdf-highlighter-extended";
-import type { ViewportHighlight } from "react-pdf-highlighter-extended";
+import { activeHighlightStore } from "./activeHighlightStore";
 import { ExtendedHighlight } from "./types";
-import { HighlightColor } from "@/lib/schema";
 
-// Map highlight color names to rgba values
-const HIGHLIGHT_COLOR_MAP: Record<HighlightColor, string> = {
-	yellow: "rgba(255, 235, 59, 0.4)",
-	green: "rgba(76, 175, 80, 0.4)",
-	blue: "rgba(66, 165, 245, 0.4)",
-	pink: "rgba(236, 64, 122, 0.4)",
-	purple: "rgba(171, 71, 188, 0.4)",
+// Map highlight color names to rgba values: [inactive, active]
+// Inactive uses low opacity; active uses the original "normal" color
+const HIGHLIGHT_COLOR_MAP: Record<HighlightColor, [string, string]> = {
+	yellow: ["rgba(255, 235, 59, 0.1)",  "rgba(255, 235, 59, 0.4)"],
+	green:  ["rgba(76, 175, 80, 0.1)",   "rgba(76, 175, 80, 0.4)"],
+	blue:   ["rgba(66, 165, 245, 0.1)",  "rgba(66, 165, 245, 0.4)"],
+	pink:   ["rgba(236, 64, 122, 0.1)",  "rgba(236, 64, 122, 0.4)"],
+	purple: ["rgba(171, 71, 188, 0.1)",  "rgba(171, 71, 188, 0.4)"],
 };
 
 interface HighlightContainerProps {
@@ -26,18 +29,24 @@ export function HighlightContainer({ onHighlightClick }: HighlightContainerProps
 	const { highlight, isScrolledTo } =
 		useHighlightContainerContext<ExtendedHighlight>();
 
+	// Subscribe to the module-level store so this component re-renders when
+	// activeHighlight changes — even though it lives in a separate React root.
+	const [activeHighlightId, setActiveHighlightId] = useState(activeHighlightStore.get());
+	useEffect(() => activeHighlightStore.subscribe(setActiveHighlightId), []);
+
 	const isTextHighlight = highlight.type === "text";
+	const isActive = highlight.id === activeHighlightId;
 
 	const handleClick = (event: React.MouseEvent) => {
 		event.stopPropagation();
 		onHighlightClick(highlight, event.nativeEvent);
 	};
 
-	// Determine highlight color: assistant highlights use purple, user highlights use their selected color
+	// Inactive highlights are dimmed; active highlight uses the original normal color
 	const highlightColor =
 		highlight.role === "assistant"
-			? "rgba(168, 85, 247, 0.3)" // purple for AI highlights
-			: HIGHLIGHT_COLOR_MAP[highlight.color || "blue"]; // user's selected color, default to blue
+			? isActive ? "rgba(168, 85, 247, 0.3)" : "rgba(168, 85, 247, 0.15)"
+			: HIGHLIGHT_COLOR_MAP[highlight.color || "blue"][isActive ? 1 : 0];
 
 	if (isTextHighlight) {
 		return (

--- a/client/src/components/pdf-viewer/HighlightContainer.tsx
+++ b/client/src/components/pdf-viewer/HighlightContainer.tsx
@@ -35,7 +35,7 @@ export function HighlightContainer({ onHighlightClick }: HighlightContainerProps
 		onHighlightClick(highlight, event.nativeEvent);
 	};
 
-	// Inactive highlights are dimmed; active highlight uses the original normal color
+	// Solid hex fills from highlightColors.ts (inactive vs active).
 	const highlightColor =
 		highlight.role === "assistant"
 			? getAssistantHighlightBackgroundRgba(isActive)

--- a/client/src/components/pdf-viewer/HighlightContainer.tsx
+++ b/client/src/components/pdf-viewer/HighlightContainer.tsx
@@ -43,7 +43,11 @@ export function HighlightContainer({ onHighlightClick }: HighlightContainerProps
 
 	if (isTextHighlight) {
 		return (
-			<div onClick={handleClick} style={{ cursor: "pointer" }}>
+			<div
+				data-pdf-text-highlight=""
+				onClick={handleClick}
+				style={{ cursor: "pointer" }}
+			>
 				<TextHighlight
 					isScrolledTo={isScrolledTo}
 					highlight={highlight}
@@ -56,7 +60,11 @@ export function HighlightContainer({ onHighlightClick }: HighlightContainerProps
 	}
 
 	return (
-		<div onClick={handleClick} style={{ cursor: "pointer" }}>
+		<div
+			data-pdf-text-highlight=""
+			onClick={handleClick}
+			style={{ cursor: "pointer" }}
+		>
 			<AreaHighlight
 				isScrolledTo={isScrolledTo}
 				highlight={highlight}

--- a/client/src/components/pdf-viewer/HighlightContainer.tsx
+++ b/client/src/components/pdf-viewer/HighlightContainer.tsx
@@ -45,6 +45,7 @@ export function HighlightContainer({ onHighlightClick }: HighlightContainerProps
 		return (
 			<div
 				data-pdf-text-highlight=""
+				data-highlight-id={highlight.id || ""}
 				onClick={handleClick}
 				style={{ cursor: "pointer" }}
 			>
@@ -62,6 +63,7 @@ export function HighlightContainer({ onHighlightClick }: HighlightContainerProps
 	return (
 		<div
 			data-pdf-text-highlight=""
+			data-highlight-id={highlight.id || ""}
 			onClick={handleClick}
 			style={{ cursor: "pointer" }}
 		>

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -15,6 +15,9 @@ import {
 	Highlighter,
 	Maximize2,
 	Minimize2,
+	EllipsisVertical,
+	ZoomIn,
+	ZoomOut,
 	ToggleLeft,
 	ToggleRight,
 } from "lucide-react";
@@ -135,7 +138,7 @@ export function PdfToolbar({
 			</div>
 
 			{/* Separator */}
-			<div className="h-5 w-px bg-gray-300 mx-3" />
+			<div className="h-5 w-px bg-gray-300 mx-1.5 md:mx-3" />
 
 			{/* Center section: Search */}
 			<div className="flex items-center gap-1">
@@ -217,7 +220,7 @@ export function PdfToolbar({
 			</div>
 
 			{/* Separator */}
-			<div className="h-5 w-px bg-gray-300 mx-3" />
+			<div className="h-5 w-px bg-gray-300 mx-1.5 md:mx-3" />
 
 			{/* Annotation controls: color picker + visibility toggle in a pill */}
 			<div className="flex items-center gap-0.5 rounded-md border border-gray-200 dark:border-zinc-700 px-0.5 py-0.5">
@@ -280,8 +283,8 @@ export function PdfToolbar({
 			{/* Spacer */}
 			<div className="flex-1" />
 
-			{/* Right section: Zoom + Status */}
-			<div className="flex items-center gap-3">
+			{/* Right section: Zoom + Status + Focus (desktop) */}
+			<div className="hidden md:flex items-center gap-3">
 				{/* Zoom controls */}
 				<div className="flex items-center gap-1">
 					<Button
@@ -344,6 +347,43 @@ export function PdfToolbar({
 						{isReadMode ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
 					</Button>
 				)}
+			</div>
+
+			{/* Right section: overflow menu (mobile) */}
+			<div className="flex md:hidden items-center">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button size="sm" variant="ghost" className="h-8 w-8 p-0">
+							<EllipsisVertical size={16} />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="min-w-40">
+						<DropdownMenuItem onClick={zoomIn}>
+							<ZoomIn size={14} className="mr-2" />
+							Zoom in
+						</DropdownMenuItem>
+						<DropdownMenuItem onClick={zoomOut}>
+							<ZoomOut size={14} className="mr-2" />
+							Zoom out
+						</DropdownMenuItem>
+						{paperStatus && (
+							<>
+								<DropdownMenuItem onClick={() => handleStatusChange("todo")}>
+									{getStatusIcon("todo")}
+									Todo
+								</DropdownMenuItem>
+								<DropdownMenuItem onClick={() => handleStatusChange("reading")}>
+									{getStatusIcon("reading")}
+									Reading
+								</DropdownMenuItem>
+								<DropdownMenuItem onClick={() => handleStatusChange("completed")}>
+									{getStatusIcon("completed")}
+									Completed
+								</DropdownMenuItem>
+							</>
+						)}
+					</DropdownMenuContent>
+				</DropdownMenu>
 			</div>
 		</div>
 	);

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -232,8 +232,8 @@ export function PdfToolbar({
 							className="h-7 px-2 gap-1.5"
 							title="Highlight color"
 						>
-							<Highlighter size={14} />
-							<div className={`w-3 h-3 rounded-sm ${currentColorConfig.bg}`} />
+							<Highlighter size={16} />
+							<div className={`w-3.5 h-3.5 rounded-sm ${currentColorConfig.bg}`} />
 						</Button>
 					</DropdownMenuTrigger>
 					<DropdownMenuContent align="start" className="min-w-0">
@@ -258,9 +258,9 @@ export function PdfToolbar({
 						type="button"
 						size="sm"
 						variant="ghost"
-						className={`h-7 w-7 p-0 ${
+						className={`h-7 px-2 ${
 							showAnnotationCards
-								? "text-secondary-foreground hover:bg-muted dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground"
+								? "bg-blue-100 text-blue-600 hover:bg-blue-200 dark:bg-blue-900/50 dark:text-blue-400 dark:hover:bg-blue-900/70"
 								: "text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
 						}`}
 						onClick={onToggleAnnotationCards}
@@ -275,7 +275,7 @@ export function PdfToolbar({
 								: "Show inline annotations"
 						}
 					>
-						{showAnnotationCards ? <ToggleRight size={14} /> : <ToggleLeft size={14} />}
+						{showAnnotationCards ? <ToggleRight className="size-5" /> : <ToggleLeft className="size-5" />}
 					</Button>
 				)}
 			</div>

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -61,7 +61,10 @@ interface PdfToolbarProps {
 	highlightColor: HighlightColor;
 	setHighlightColor: (color: HighlightColor) => void;
 
-	/** Margin annotation cards visibility (omit when not wired). */
+	/**
+	 * When set (e.g. mobile reader with no PaperSidebar), show the annotation visibility
+	 * toggle on this bar. Desktop uses PaperSidebar at the bottom of the floating tool rail.
+	 */
 	showAnnotationCards?: boolean;
 	onToggleAnnotationCards?: () => void;
 }

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -13,6 +13,8 @@ import {
 	Search,
 	X,
 	Highlighter,
+	Maximize2,
+	Minimize2,
 	ToggleLeft,
 	ToggleRight,
 } from "lucide-react";
@@ -67,6 +69,10 @@ interface PdfToolbarProps {
 	 */
 	showAnnotationCards?: boolean;
 	onToggleAnnotationCards?: () => void;
+
+	/** Focus / read mode: expand PDF to fill the viewport, hiding the side panel. */
+	isReadMode?: boolean;
+	onToggleReadMode?: () => void;
 }
 
 export function PdfToolbar({
@@ -96,6 +102,8 @@ export function PdfToolbar({
 	setHighlightColor,
 	showAnnotationCards = true,
 	onToggleAnnotationCards,
+	isReadMode = false,
+	onToggleReadMode,
 }: PdfToolbarProps) {
 	const currentColorConfig =
 		HIGHLIGHT_COLOR_SWATCHES.find((c) => c.color === highlightColor) || HIGHLIGHT_COLOR_SWATCHES[2];
@@ -321,6 +329,20 @@ export function PdfToolbar({
 							</DropdownMenuItem>
 						</DropdownMenuContent>
 					</DropdownMenu>
+				)}
+
+				{/* Focus / read mode toggle */}
+				{onToggleReadMode && (
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-8 w-8 p-0"
+						onClick={onToggleReadMode}
+						title={isReadMode ? "Exit focus mode" : "Focus mode"}
+						aria-label={isReadMode ? "Exit focus mode" : "Focus mode"}
+					>
+						{isReadMode ? <Minimize2 size={16} /> : <Maximize2 size={16} />}
+					</Button>
 				)}
 			</div>
 		</div>

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -13,6 +13,8 @@ import {
 	Search,
 	X,
 	Highlighter,
+	Eye,
+	EyeOff,
 } from "lucide-react";
 import {
 	DropdownMenu,
@@ -66,6 +68,10 @@ interface PdfToolbarProps {
 	// Highlight color
 	highlightColor: HighlightColor;
 	setHighlightColor: (color: HighlightColor) => void;
+
+	/** Margin annotation cards visibility (omit when not wired). */
+	showAnnotationCards?: boolean;
+	onToggleAnnotationCards?: () => void;
 }
 
 export function PdfToolbar({
@@ -93,6 +99,8 @@ export function PdfToolbar({
 	handleStatusChange = () => { },
 	highlightColor,
 	setHighlightColor,
+	showAnnotationCards = true,
+	onToggleAnnotationCards,
 }: PdfToolbarProps) {
 	const currentColorConfig = HIGHLIGHT_COLORS.find((c) => c.color === highlightColor) || HIGHLIGHT_COLORS[2];
 	return (
@@ -266,7 +274,24 @@ export function PdfToolbar({
 					</Button>
 				</div>
 
-				{/* Status dropdown */}
+				{onToggleAnnotationCards && (
+					<Button
+						type="button"
+						size="sm"
+						variant="ghost"
+						className={`h-8 w-8 p-0 ${
+							showAnnotationCards
+								? "text-secondary-foreground hover:bg-muted dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground"
+								: "text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+						}`}
+						onClick={onToggleAnnotationCards}
+						title={showAnnotationCards ? "Hide annotations" : "Show annotations"}
+					>
+						{showAnnotationCards ? <Eye size={16} /> : <EyeOff size={16} />}
+					</Button>
+				)}
+
+				{/* Reading status */}
 				{paperStatus && (
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -13,8 +13,8 @@ import {
 	Search,
 	X,
 	Highlighter,
-	Eye,
-	EyeOff,
+	ToggleLeft,
+	ToggleRight,
 } from "lucide-react";
 import {
 	DropdownMenu,
@@ -112,7 +112,7 @@ export function PdfToolbar({
 				>
 					<ArrowLeft size={16} />
 				</Button>
-				<span className="text-xs text-secondary-foreground min-w-[4rem] text-center">
+				<span className="text-xs text-secondary-foreground min-w-16 text-center">
 					{currentPage} / {numPages || "?"}
 				</span>
 				<Button
@@ -211,35 +211,63 @@ export function PdfToolbar({
 			{/* Separator */}
 			<div className="h-5 w-px bg-gray-300 mx-3" />
 
-			{/* Highlight color: marker icon + swatch (original layout) */}
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
+			{/* Annotation controls: color picker + visibility toggle in a pill */}
+			<div className="flex items-center gap-0.5 rounded-md border border-gray-200 dark:border-zinc-700 px-0.5 py-0.5">
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							size="sm"
+							variant="ghost"
+							className="h-7 px-2 gap-1.5"
+							title="Highlight color"
+						>
+							<Highlighter size={14} />
+							<div className={`w-3 h-3 rounded-sm ${currentColorConfig.bg}`} />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="start" className="min-w-0">
+						<div className="flex gap-1 p-1">
+							{HIGHLIGHT_COLOR_SWATCHES.map(({ color, bg }) => (
+								<button
+									key={color}
+									type="button"
+									onClick={() => setHighlightColor(color)}
+									className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
+										highlightColor === color ? "ring-2 ring-offset-1 ring-gray-400" : ""
+									}`}
+									title={color}
+								/>
+							))}
+						</div>
+					</DropdownMenuContent>
+				</DropdownMenu>
+
+				{onToggleAnnotationCards && (
 					<Button
+						type="button"
 						size="sm"
 						variant="ghost"
-						className="h-8 px-2 gap-1.5"
-						title="Highlight color"
+						className={`h-7 w-7 p-0 ${
+							showAnnotationCards
+								? "text-secondary-foreground hover:bg-muted dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground"
+								: "text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
+						}`}
+						onClick={onToggleAnnotationCards}
+						title={
+							showAnnotationCards
+								? "Hide inline annotations"
+								: "Show inline annotations"
+						}
+						aria-label={
+							showAnnotationCards
+								? "Hide inline annotations"
+								: "Show inline annotations"
+						}
 					>
-						<Highlighter size={16} />
-						<div className={`w-3 h-3 rounded-sm ${currentColorConfig.bg}`} />
+						{showAnnotationCards ? <ToggleRight size={14} /> : <ToggleLeft size={14} />}
 					</Button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="start" className="min-w-0">
-					<div className="flex gap-1 p-1">
-						{HIGHLIGHT_COLOR_SWATCHES.map(({ color, bg }) => (
-							<button
-								key={color}
-								type="button"
-								onClick={() => setHighlightColor(color)}
-								className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
-									highlightColor === color ? "ring-2 ring-offset-1 ring-gray-400" : ""
-								}`}
-								title={color}
-							/>
-						))}
-					</div>
-				</DropdownMenuContent>
-			</DropdownMenu>
+				)}
+			</div>
 
 			{/* Spacer */}
 			<div className="flex-1" />
@@ -268,32 +296,6 @@ export function PdfToolbar({
 						<Plus size={16} />
 					</Button>
 				</div>
-
-				{onToggleAnnotationCards && (
-					<Button
-						type="button"
-						size="sm"
-						variant="ghost"
-						className={`h-8 w-8 p-0 ${
-							showAnnotationCards
-								? "text-secondary-foreground hover:bg-muted dark:text-zinc-200 dark:hover:bg-zinc-800 dark:hover:text-foreground"
-								: "text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
-						}`}
-						onClick={onToggleAnnotationCards}
-						title={
-							showAnnotationCards
-								? "Hide inline annotations"
-								: "Show inline annotations"
-						}
-						aria-label={
-							showAnnotationCards
-								? "Hide inline annotations"
-								: "Show inline annotations"
-						}
-					>
-						{showAnnotationCards ? <Eye size={16} /> : <EyeOff size={16} />}
-					</Button>
-				)}
 
 				{/* Reading status */}
 				{paperStatus && (

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -62,8 +62,8 @@ interface PdfToolbarProps {
 	setHighlightColor: (color: HighlightColor) => void;
 
 	/**
-	 * When set (e.g. mobile reader with no PaperSidebar), show the annotation visibility
-	 * toggle on this bar. Desktop uses PaperSidebar at the bottom of the floating tool rail.
+	 * When set, show the inline-annotation visibility toggle on this bar (next to zoom).
+	 * Omit when the parent shows the control elsewhere (e.g. mobile Tools panel with no PDF toolbar).
 	 */
 	showAnnotationCards?: boolean;
 	onToggleAnnotationCards?: () => void;
@@ -280,7 +280,16 @@ export function PdfToolbar({
 								: "text-muted-foreground hover:bg-muted dark:text-zinc-400 dark:hover:bg-zinc-800 dark:hover:text-zinc-200"
 						}`}
 						onClick={onToggleAnnotationCards}
-						title={showAnnotationCards ? "Hide annotations" : "Show annotations"}
+						title={
+							showAnnotationCards
+								? "Hide inline annotations"
+								: "Show inline annotations"
+						}
+						aria-label={
+							showAnnotationCards
+								? "Hide inline annotations"
+								: "Show inline annotations"
+						}
 					>
 						{showAnnotationCards ? <Eye size={16} /> : <EyeOff size={16} />}
 					</Button>

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -12,7 +12,6 @@ import {
 	ChevronDown,
 	Search,
 	X,
-	Highlighter,
 	Eye,
 	EyeOff,
 } from "lucide-react";
@@ -24,15 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { getStatusIcon, PaperStatus } from "@/components/utils/PdfStatus";
 import { HighlightColor } from "@/lib/schema";
-
-// Color configuration for highlights
-const HIGHLIGHT_COLORS: { color: HighlightColor; bg: string; label: string }[] = [
-	{ color: "yellow", bg: "bg-yellow-300", label: "Yellow" },
-	{ color: "green", bg: "bg-green-400", label: "Green" },
-	{ color: "blue", bg: "bg-blue-400", label: "Blue" },
-	{ color: "pink", bg: "bg-pink-400", label: "Pink" },
-	{ color: "purple", bg: "bg-purple-400", label: "Purple" },
-];
+import { HIGHLIGHT_COLOR_SWATCHES } from "@/components/pdf-viewer/highlightColors";
 
 interface PdfToolbarProps {
 	// Page navigation
@@ -72,6 +63,8 @@ interface PdfToolbarProps {
 	/** Margin annotation cards visibility (omit when not wired). */
 	showAnnotationCards?: boolean;
 	onToggleAnnotationCards?: () => void;
+	/** When false, color + eye are omitted (e.g. shown on PaperSidebar). Default true. */
+	showColorAndEye?: boolean;
 }
 
 export function PdfToolbar({
@@ -101,8 +94,10 @@ export function PdfToolbar({
 	setHighlightColor,
 	showAnnotationCards = true,
 	onToggleAnnotationCards,
+	showColorAndEye = true,
 }: PdfToolbarProps) {
-	const currentColorConfig = HIGHLIGHT_COLORS.find((c) => c.color === highlightColor) || HIGHLIGHT_COLORS[2];
+	const currentColorConfig =
+		HIGHLIGHT_COLOR_SWATCHES.find((c) => c.color === highlightColor) || HIGHLIGHT_COLOR_SWATCHES[2];
 	return (
 		<div className="sticky top-0 z-10 flex items-center bg-white/80 dark:bg-black/80 backdrop-blur-sm px-3 py-2 w-full border-b border-gray-300">
 			{/* Left section: Page navigation */}
@@ -212,39 +207,43 @@ export function PdfToolbar({
 				)}
 			</div>
 
-			{/* Separator */}
-			<div className="h-5 w-px bg-gray-300 mx-3" />
+			{showColorAndEye && (
+				<>
+					{/* Separator */}
+					<div className="h-5 w-px bg-gray-300 mx-3" />
 
-			{/* Highlight color picker */}
-			<DropdownMenu>
-				<DropdownMenuTrigger asChild>
-					<Button
-						size="sm"
-						variant="ghost"
-						className="h-8 px-2 gap-1.5"
-						title="Highlight color"
-					>
-						<Highlighter size={16} />
-						<div
-							className={`w-3 h-3 rounded-sm ${currentColorConfig.bg}`}
-						/>
-					</Button>
-				</DropdownMenuTrigger>
-				<DropdownMenuContent align="start" className="min-w-0">
-					<div className="flex gap-1 p-1">
-						{HIGHLIGHT_COLORS.map(({ color, bg }) => (
-							<button
-								key={color}
-								onClick={() => setHighlightColor(color)}
-								className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
-									highlightColor === color ? "ring-2 ring-offset-1 ring-gray-400" : ""
-								}`}
-								title={color}
-							/>
-						))}
-					</div>
-				</DropdownMenuContent>
-			</DropdownMenu>
+					{/* Highlight color picker — circle only (e.g. mobile reader when sidebar is hidden) */}
+					<DropdownMenu>
+						<DropdownMenuTrigger asChild>
+							<Button
+								size="sm"
+								variant="ghost"
+								className="h-8 w-8 p-0 rounded-full"
+								title="Highlight color"
+							>
+								<div
+									className={`w-4 h-4 rounded-full ${currentColorConfig.bg} ring-1 ring-border`}
+								/>
+							</Button>
+						</DropdownMenuTrigger>
+						<DropdownMenuContent align="start" className="min-w-0">
+							<div className="flex gap-1 p-1">
+								{HIGHLIGHT_COLOR_SWATCHES.map(({ color, bg }) => (
+									<button
+										key={color}
+										type="button"
+										onClick={() => setHighlightColor(color)}
+										className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
+											highlightColor === color ? "ring-2 ring-offset-1 ring-gray-400" : ""
+										}`}
+										title={color}
+									/>
+								))}
+							</div>
+						</DropdownMenuContent>
+					</DropdownMenu>
+				</>
+			)}
 
 			{/* Spacer */}
 			<div className="flex-1" />
@@ -274,7 +273,7 @@ export function PdfToolbar({
 					</Button>
 				</div>
 
-				{onToggleAnnotationCards && (
+				{showColorAndEye && onToggleAnnotationCards && (
 					<Button
 						type="button"
 						size="sm"

--- a/client/src/components/pdf-viewer/PdfToolbar.tsx
+++ b/client/src/components/pdf-viewer/PdfToolbar.tsx
@@ -12,6 +12,7 @@ import {
 	ChevronDown,
 	Search,
 	X,
+	Highlighter,
 	Eye,
 	EyeOff,
 } from "lucide-react";
@@ -63,8 +64,6 @@ interface PdfToolbarProps {
 	/** Margin annotation cards visibility (omit when not wired). */
 	showAnnotationCards?: boolean;
 	onToggleAnnotationCards?: () => void;
-	/** When false, color + eye are omitted (e.g. shown on PaperSidebar). Default true. */
-	showColorAndEye?: boolean;
 }
 
 export function PdfToolbar({
@@ -94,7 +93,6 @@ export function PdfToolbar({
 	setHighlightColor,
 	showAnnotationCards = true,
 	onToggleAnnotationCards,
-	showColorAndEye = true,
 }: PdfToolbarProps) {
 	const currentColorConfig =
 		HIGHLIGHT_COLOR_SWATCHES.find((c) => c.color === highlightColor) || HIGHLIGHT_COLOR_SWATCHES[2];
@@ -207,43 +205,38 @@ export function PdfToolbar({
 				)}
 			</div>
 
-			{showColorAndEye && (
-				<>
-					{/* Separator */}
-					<div className="h-5 w-px bg-gray-300 mx-3" />
+			{/* Separator */}
+			<div className="h-5 w-px bg-gray-300 mx-3" />
 
-					{/* Highlight color picker — circle only (e.g. mobile reader when sidebar is hidden) */}
-					<DropdownMenu>
-						<DropdownMenuTrigger asChild>
-							<Button
-								size="sm"
-								variant="ghost"
-								className="h-8 w-8 p-0 rounded-full"
-								title="Highlight color"
-							>
-								<div
-									className={`w-4 h-4 rounded-full ${currentColorConfig.bg} ring-1 ring-border`}
-								/>
-							</Button>
-						</DropdownMenuTrigger>
-						<DropdownMenuContent align="start" className="min-w-0">
-							<div className="flex gap-1 p-1">
-								{HIGHLIGHT_COLOR_SWATCHES.map(({ color, bg }) => (
-									<button
-										key={color}
-										type="button"
-										onClick={() => setHighlightColor(color)}
-										className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
-											highlightColor === color ? "ring-2 ring-offset-1 ring-gray-400" : ""
-										}`}
-										title={color}
-									/>
-								))}
-							</div>
-						</DropdownMenuContent>
-					</DropdownMenu>
-				</>
-			)}
+			{/* Highlight color: marker icon + swatch (original layout) */}
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button
+						size="sm"
+						variant="ghost"
+						className="h-8 px-2 gap-1.5"
+						title="Highlight color"
+					>
+						<Highlighter size={16} />
+						<div className={`w-3 h-3 rounded-sm ${currentColorConfig.bg}`} />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="start" className="min-w-0">
+					<div className="flex gap-1 p-1">
+						{HIGHLIGHT_COLOR_SWATCHES.map(({ color, bg }) => (
+							<button
+								key={color}
+								type="button"
+								onClick={() => setHighlightColor(color)}
+								className={`w-6 h-6 rounded-sm ${bg} hover:scale-110 transition-transform ${
+									highlightColor === color ? "ring-2 ring-offset-1 ring-gray-400" : ""
+								}`}
+								title={color}
+							/>
+						))}
+					</div>
+				</DropdownMenuContent>
+			</DropdownMenu>
 
 			{/* Spacer */}
 			<div className="flex-1" />
@@ -273,7 +266,7 @@ export function PdfToolbar({
 					</Button>
 				</div>
 
-				{showColorAndEye && onToggleAnnotationCards && (
+				{onToggleAnnotationCards && (
 					<Button
 						type="button"
 						size="sm"

--- a/client/src/components/pdf-viewer/activeHighlightStore.ts
+++ b/client/src/components/pdf-viewer/activeHighlightStore.ts
@@ -1,0 +1,16 @@
+type Listener = (id: string | undefined) => void;
+
+let _current: string | undefined;
+const _listeners = new Set<Listener>();
+
+export const activeHighlightStore = {
+	get: () => _current,
+	set: (id: string | undefined) => {
+		_current = id;
+		_listeners.forEach((l) => l(id));
+	},
+	subscribe: (listener: Listener) => {
+		_listeners.add(listener);
+		return () => { _listeners.delete(listener); };
+	},
+};

--- a/client/src/components/pdf-viewer/findTextPosition.ts
+++ b/client/src/components/pdf-viewer/findTextPosition.ts
@@ -256,7 +256,8 @@ export function createTextHighlightOverlays(
 					highlight.style.backgroundColor = backgroundColor;
 					highlight.style.borderRadius = "2px";
 					highlight.style.pointerEvents = "none";
-					highlight.style.mixBlendMode = "multiply";
+					// No mix-blend-multiply: it darkens vs react-pdf-highlighter TextHighlight (solid rgba),
+					// so position-backed and overlay-backed highlights look inconsistent.
 
 					textLayer.appendChild(highlight);
 					matchElements.push(highlight);

--- a/client/src/components/pdf-viewer/highlightColors.ts
+++ b/client/src/components/pdf-viewer/highlightColors.ts
@@ -16,21 +16,21 @@ export const HIGHLIGHT_COLOR_SWATCHES: {
 /**
  * Soft solid fills for PDF text (opaque hex). Using translucent RGBA on saturated base
  * colors still looks loud on white, and overlapping line rects stack alpha and create dark bands.
- * [inactive, active] — inactive stays a light wash; active uses a clearly darker/saturated hex
+ * [inactive, active] — inactive is ~Tailwind 100 (readable on white); active is clearly darker
  * so the focused highlight is easy to spot (not “two pastels”).
  */
 export const USER_HIGHLIGHT_FILL: Record<HighlightColor, [string, string]> = {
-	yellow: ["#FFFBEB", "#FDE68A"],
-	green: ["#F0FDF4", "#86EFAC"],
-	blue: ["#EFF6FF", "#93C5FD"],
-	pink: ["#FDF2F8", "#F9A8D4"],
-	purple: ["#FAF5FF", "#C4B5FD"],
+	yellow: ["#FEF3C7", "#FDE68A"],
+	green: ["#DCFCE7", "#86EFAC"],
+	blue: ["#DBEAFE", "#93C5FD"],
+	pink: ["#FCE7F3", "#F9A8D4"],
+	purple: ["#F3E8FF", "#C4B5FD"],
 };
 
 /** @deprecated Use USER_HIGHLIGHT_FILL — kept for re-exports */
 export const USER_HIGHLIGHT_RGBA = USER_HIGHLIGHT_FILL;
 
-const ASSISTANT_HIGHLIGHT_FILL = ["#F5F3FF", "#A78BFA"] as const;
+const ASSISTANT_HIGHLIGHT_FILL = ["#EDE9FE", "#A78BFA"] as const;
 
 export function getUserHighlightBackgroundRgba(
 	color: HighlightColor | undefined,
@@ -43,5 +43,5 @@ export function getAssistantHighlightBackgroundRgba(isActive: boolean): string {
 	return ASSISTANT_HIGHLIGHT_FILL[isActive ? 1 : 0];
 }
 
-/** Ephemeral text selection while dragging (matches blue idle fill). */
-export const PDF_TEXT_SELECTION_FILL = "#EFF6FF";
+/** Ephemeral text selection while dragging (matches blue inactive fill). */
+export const PDF_TEXT_SELECTION_FILL = "#DBEAFE";

--- a/client/src/components/pdf-viewer/highlightColors.ts
+++ b/client/src/components/pdf-viewer/highlightColors.ts
@@ -1,0 +1,21 @@
+import type { HighlightColor } from "@/lib/schema";
+
+/** [inactive, active] rgba — inactive is lower opacity than active */
+export const USER_HIGHLIGHT_RGBA: Record<HighlightColor, [string, string]> = {
+	yellow: ["rgba(255, 235, 59, 0.1)", "rgba(255, 235, 59, 0.4)"],
+	green: ["rgba(76, 175, 80, 0.1)", "rgba(76, 175, 80, 0.4)"],
+	blue: ["rgba(66, 165, 245, 0.1)", "rgba(66, 165, 245, 0.4)"],
+	pink: ["rgba(236, 64, 122, 0.1)", "rgba(236, 64, 122, 0.4)"],
+	purple: ["rgba(171, 71, 188, 0.1)", "rgba(171, 71, 188, 0.4)"],
+};
+
+export function getUserHighlightBackgroundRgba(
+	color: HighlightColor | undefined,
+	isActive: boolean
+): string {
+	return USER_HIGHLIGHT_RGBA[color || "blue"][isActive ? 1 : 0];
+}
+
+export function getAssistantHighlightBackgroundRgba(isActive: boolean): string {
+	return isActive ? "rgba(168, 85, 247, 0.3)" : "rgba(168, 85, 247, 0.15)";
+}

--- a/client/src/components/pdf-viewer/highlightColors.ts
+++ b/client/src/components/pdf-viewer/highlightColors.ts
@@ -13,23 +13,35 @@ export const HIGHLIGHT_COLOR_SWATCHES: {
 	{ color: "purple", bg: "bg-purple-400", label: "Purple" },
 ];
 
-/** [inactive, active] rgba — inactive is lower opacity than active */
-export const USER_HIGHLIGHT_RGBA: Record<HighlightColor, [string, string]> = {
-	yellow: ["rgba(255, 235, 59, 0.1)", "rgba(255, 235, 59, 0.4)"],
-	green: ["rgba(76, 175, 80, 0.1)", "rgba(76, 175, 80, 0.4)"],
-	blue: ["rgba(66, 165, 245, 0.1)", "rgba(66, 165, 245, 0.4)"],
-	pink: ["rgba(236, 64, 122, 0.1)", "rgba(236, 64, 122, 0.4)"],
-	purple: ["rgba(171, 71, 188, 0.1)", "rgba(171, 71, 188, 0.4)"],
+/**
+ * Soft solid fills for PDF text (opaque hex). Using translucent RGBA on saturated base
+ * colors still looks loud on white, and overlapping line rects stack alpha and create dark bands.
+ * [inactive, active] — inactive stays a light wash; active uses a clearly darker/saturated hex
+ * so the focused highlight is easy to spot (not “two pastels”).
+ */
+export const USER_HIGHLIGHT_FILL: Record<HighlightColor, [string, string]> = {
+	yellow: ["#FFFBEB", "#FDE68A"],
+	green: ["#F0FDF4", "#86EFAC"],
+	blue: ["#EFF6FF", "#93C5FD"],
+	pink: ["#FDF2F8", "#F9A8D4"],
+	purple: ["#FAF5FF", "#C4B5FD"],
 };
+
+/** @deprecated Use USER_HIGHLIGHT_FILL — kept for re-exports */
+export const USER_HIGHLIGHT_RGBA = USER_HIGHLIGHT_FILL;
+
+const ASSISTANT_HIGHLIGHT_FILL = ["#F5F3FF", "#A78BFA"] as const;
 
 export function getUserHighlightBackgroundRgba(
 	color: HighlightColor | undefined,
 	isActive: boolean
 ): string {
-	return USER_HIGHLIGHT_RGBA[color || "blue"][isActive ? 1 : 0];
+	return USER_HIGHLIGHT_FILL[color || "blue"][isActive ? 1 : 0];
 }
 
 export function getAssistantHighlightBackgroundRgba(isActive: boolean): string {
-	// Inactive opacity matches user highlights (0.1) so all non-selected highlights look consistent.
-	return isActive ? "rgba(168, 85, 247, 0.3)" : "rgba(168, 85, 247, 0.1)";
+	return ASSISTANT_HIGHLIGHT_FILL[isActive ? 1 : 0];
 }
+
+/** Ephemeral text selection while dragging (matches blue idle fill). */
+export const PDF_TEXT_SELECTION_FILL = "#EFF6FF";

--- a/client/src/components/pdf-viewer/highlightColors.ts
+++ b/client/src/components/pdf-viewer/highlightColors.ts
@@ -1,5 +1,18 @@
 import type { HighlightColor } from "@/lib/schema";
 
+/** Tailwind classes for highlight color picker swatches (PDF toolbar / floating sidebar). */
+export const HIGHLIGHT_COLOR_SWATCHES: {
+	color: HighlightColor;
+	bg: string;
+	label: string;
+}[] = [
+	{ color: "yellow", bg: "bg-yellow-300", label: "Yellow" },
+	{ color: "green", bg: "bg-green-400", label: "Green" },
+	{ color: "blue", bg: "bg-blue-400", label: "Blue" },
+	{ color: "pink", bg: "bg-pink-400", label: "Pink" },
+	{ color: "purple", bg: "bg-purple-400", label: "Purple" },
+];
+
 /** [inactive, active] rgba — inactive is lower opacity than active */
 export const USER_HIGHLIGHT_RGBA: Record<HighlightColor, [string, string]> = {
 	yellow: ["rgba(255, 235, 59, 0.1)", "rgba(255, 235, 59, 0.4)"],
@@ -17,5 +30,6 @@ export function getUserHighlightBackgroundRgba(
 }
 
 export function getAssistantHighlightBackgroundRgba(isActive: boolean): string {
-	return isActive ? "rgba(168, 85, 247, 0.3)" : "rgba(168, 85, 247, 0.15)";
+	// Inactive opacity matches user highlights (0.1) so all non-selected highlights look consistent.
+	return isActive ? "rgba(168, 85, 247, 0.3)" : "rgba(168, 85, 247, 0.1)";
 }

--- a/client/src/components/pdf-viewer/index.ts
+++ b/client/src/components/pdf-viewer/index.ts
@@ -6,3 +6,8 @@ export { activeHighlightStore } from "./activeHighlightStore";
 export { usePdfSearch } from "./usePdfSearch";
 export { PdfToolbar } from "./PdfToolbar";
 export { findTextPages, createTextHighlightOverlays, removeHighlightOverlays, computeScaledPositionFromTextLayer } from "./findTextPosition";
+export {
+	getAssistantHighlightBackgroundRgba,
+	getUserHighlightBackgroundRgba,
+	USER_HIGHLIGHT_RGBA,
+} from "./highlightColors";

--- a/client/src/components/pdf-viewer/index.ts
+++ b/client/src/components/pdf-viewer/index.ts
@@ -9,5 +9,7 @@ export { findTextPages, createTextHighlightOverlays, removeHighlightOverlays, co
 export {
 	getAssistantHighlightBackgroundRgba,
 	getUserHighlightBackgroundRgba,
+	PDF_TEXT_SELECTION_FILL,
+	USER_HIGHLIGHT_FILL,
 	USER_HIGHLIGHT_RGBA,
 } from "./highlightColors";

--- a/client/src/components/pdf-viewer/index.ts
+++ b/client/src/components/pdf-viewer/index.ts
@@ -2,6 +2,7 @@ export type { ExtendedHighlight } from "./types";
 export { paperHighlightToExtended, extendedToPaperHighlight } from "./types";
 export { normalizeForSearch, expandLatexCommands } from "./textNormalization";
 export { HighlightContainer } from "./HighlightContainer";
+export { activeHighlightStore } from "./activeHighlightStore";
 export { usePdfSearch } from "./usePdfSearch";
 export { PdfToolbar } from "./PdfToolbar";
 export { findTextPages, createTextHighlightOverlays, removeHighlightOverlays, computeScaledPositionFromTextLayer } from "./findTextPosition";

--- a/client/src/lib/auth.tsx
+++ b/client/src/lib/auth.tsx
@@ -28,14 +28,9 @@ const AUTH_STORAGE_KEY = 'auth_user';
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 export function AuthProvider({ children }: { children: ReactNode }) {
-	const [user, setUser] = useState<User | null>(() => {
-		// Initialize from localStorage if in browser environment
-		if (typeof window !== 'undefined') {
-			const storedUser = localStorage.getItem(AUTH_STORAGE_KEY);
-			return storedUser ? JSON.parse(storedUser) : null;
-		}
-		return null;
-	});
+	// Always initialize to null to match server render and avoid hydration mismatch.
+	// localStorage is read in the effect below for fast optimistic state.
+	const [user, setUser] = useState<User | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | null>(null);
 
@@ -50,6 +45,16 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 	// Check if user is logged in
 	useEffect(() => {
+		// Immediately restore cached user for fast UI update
+		const storedUser = localStorage.getItem(AUTH_STORAGE_KEY);
+		if (storedUser) {
+			try {
+				setUser(JSON.parse(storedUser));
+			} catch {
+				localStorage.removeItem(AUTH_STORAGE_KEY);
+			}
+		}
+
 		async function checkAuth() {
 			try {
 				const response = await fetchFromApi('/api/auth/me');

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -36,10 +36,21 @@ export const isDateValid = (dateString: string) => {
 export const formatDate = (dateString: string) => {
 	const date = new Date(dateString);
 	const now = new Date();
+	const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+	const isSameCalendarDay = (a: Date, b: Date) =>
+		a.getFullYear() === b.getFullYear() &&
+		a.getMonth() === b.getMonth() &&
+		a.getDate() === b.getDate();
+
+	if (isSameCalendarDay(date, now)) {
+		return `Today ${timeStr}`;
+	}
+
 	const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60);
 
 	if (diffInHours < 24) {
-		return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+		return timeStr;
 	} else if (diffInHours < 168) { // 7 days
 		return date.toLocaleDateString([], { weekday: 'short', hour: '2-digit', minute: '2-digit' });
 	} else {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -58,6 +58,36 @@ export const formatDate = (dateString: string) => {
 	}
 };
 
+/** Clock time first, then date context — e.g. "11:31 AM - Today", "9:29 PM - Jan 15" */
+export const formatAnnotationDate = (dateString: string) => {
+	const date = new Date(dateString);
+	const now = new Date();
+	const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+	const isSameCalendarDay = (a: Date, b: Date) =>
+		a.getFullYear() === b.getFullYear() &&
+		a.getMonth() === b.getMonth() &&
+		a.getDate() === b.getDate();
+
+	const dateLabel = (() => {
+		if (isSameCalendarDay(date, now)) return 'Today';
+		const yesterday = new Date(now);
+		yesterday.setDate(yesterday.getDate() - 1);
+		if (isSameCalendarDay(date, yesterday)) return 'Yesterday';
+		const diffMs = now.getTime() - date.getTime();
+		const diffDays = diffMs / (1000 * 60 * 60 * 24);
+		if (diffDays >= 0 && diffDays < 7) {
+			return date.toLocaleDateString([], { weekday: 'short' });
+		}
+		if (date.getFullYear() !== now.getFullYear()) {
+			return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
+		}
+		return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
+	})();
+
+	return `${timeStr} - ${dateLabel}`;
+};
+
 export function getAlphaHashToBackgroundColor(input: string): string {
 	if (!input) input = "User";
 	// Given a string, return a color from a predefined set based on a hash of the string, using tailwind bg-color-500 variants.

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -58,34 +58,21 @@ export const formatDate = (dateString: string) => {
 	}
 };
 
-/** Clock time first, then date context — e.g. "11:31 AM - Today", "9:29 PM - Jan 15" */
+/** Actual creation time and calendar date — e.g. "9:30 PM Apr 11", "9:30 PM Apr 11, 2024" when not the current year */
 export const formatAnnotationDate = (dateString: string) => {
+	if (!isDateValid(dateString)) return "";
 	const date = new Date(dateString);
 	const now = new Date();
-	const timeStr = date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
-
-	const isSameCalendarDay = (a: Date, b: Date) =>
-		a.getFullYear() === b.getFullYear() &&
-		a.getMonth() === b.getMonth() &&
-		a.getDate() === b.getDate();
-
-	const dateLabel = (() => {
-		if (isSameCalendarDay(date, now)) return 'Today';
-		const yesterday = new Date(now);
-		yesterday.setDate(yesterday.getDate() - 1);
-		if (isSameCalendarDay(date, yesterday)) return 'Yesterday';
-		const diffMs = now.getTime() - date.getTime();
-		const diffDays = diffMs / (1000 * 60 * 60 * 24);
-		if (diffDays >= 0 && diffDays < 7) {
-			return date.toLocaleDateString([], { weekday: 'short' });
-		}
-		if (date.getFullYear() !== now.getFullYear()) {
-			return date.toLocaleDateString([], { month: 'short', day: 'numeric', year: 'numeric' });
-		}
-		return date.toLocaleDateString([], { month: 'short', day: 'numeric' });
-	})();
-
-	return `${timeStr} - ${dateLabel}`;
+	const timeStr = date.toLocaleTimeString("en-US", {
+		hour: "numeric",
+		minute: "2-digit",
+		hour12: true,
+	});
+	const datePart =
+		date.getFullYear() !== now.getFullYear()
+			? date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+			: date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+	return `${timeStr} ${datePart}`;
 };
 
 export function getAlphaHashToBackgroundColor(input: string): string {


### PR DESCRIPTION
Hello @sabaimran,

The goal of this PR is to improve the **Annotation** experience. Summary of what I've changed:

1. Added **annotation cards on the margin** associated with highlighted text
   - [AnnotationsView.tsx](): Floating annotation card rendered in the PDF margin
   - [PdfAnnotation.ts](): React hook: fetch/add/update/delete annotations, useAnnotations
   - [PdfHighlighterViewer.tsx](): Renders note cards in the PDF scroll area, beside the page. This one consists of the logic that calculates the cards' positions relative to one another.
2. Added a new functionality called **Hide Annotations**
3. Minimize the right-side Toolbar into a **floating menu**
4. Minimize the inline annotation menu:
   - [InlineAnnotationMenu.tsx](): Context menu that appears on text selection (contains the "Annotate" action)
6. **Improved spacing** for the list of annotations in the right side panel and single annotation bubble UI
    - [Annotation.tsx]( ): updated UI of one annotation inside the side panel (avatar, user name, timestamp + content)
    - [AnnotationsView.tsx](): updated UI with better spacing and visual hierarchy

Some minor bugs:
- When zoomed in on the paper (> 100%), the annotation cards are not properly aligned
- When the paper is reopened, the chat summary is displayed, and after switching to focus mode, the annotation cards are also mispositioned (overlapped with the paper).

Lmk what you think and whether you run into any errors running the new feature. There might also be some other edge cases, but overall, this is how the feature looks (Loom video attached below):

https://www.loom.com/share/fe3e5620b4c147609c3ed59d4c808cbe