### PR TITLE
Improve project paper loads

### DIFF
--- a/client/src/app/(main)/projects/[projectId]/conversations/[conversationId]/page.tsx
+++ b/client/src/app/(main)/projects/[projectId]/conversations/[conversationId]/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useSubscription, isChatCreditAtLimit } from '@/hooks/useSubscription';
-import { fetchFromApi, fetchStreamFromApi } from '@/lib/api';
-import { useState, useEffect, FormEvent, useRef, useCallback, Suspense } from 'react';
+import { fetchFromApi, fetchStreamFromApi, getProjectPaperFileUrl } from '@/lib/api';
+import { useState, useEffect, FormEvent, useRef, useCallback, useMemo, Suspense } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import {
     Breadcrumb,
@@ -18,7 +18,7 @@ import {
     Reference,
 } from '@/lib/schema';
 import { useAuth } from '@/lib/auth';
-import { useProject } from '@/hooks/useProjects';
+import { useProject, useProjectPapers } from '@/hooks/useProjects';
 import { PaperItem } from "@/lib/schema";
 import { toast } from "sonner";
 import { ConversationView } from '@/components/ConversationView';
@@ -48,9 +48,20 @@ function ProjectConversationPageContent() {
 
     const { user, loading: authLoading } = useAuth();
     const { project } = useProject(projectId);
+    // Paper metadata only — file URLs are fetched lazily per-paper on demand.
+    const { papers: projectPapers, updatePaper } = useProjectPapers(projectId);
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const [isOwner, setIsOwner] = useState<boolean>(true);
-    const [papers, setPapers] = useState<PaperItem[]>([]);
+
+    const papers = useMemo(
+        () =>
+            [...projectPapers].sort(
+                (a: PaperItem, b: PaperItem) =>
+                    new Date(b.created_at || "").getTime() -
+                    new Date(a.created_at || "").getTime(),
+            ),
+        [projectPapers],
+    );
 
     const [currentMessage, setCurrentMessage] = useState('');
     const [isStreaming, setIsStreaming] = useState(false);
@@ -174,37 +185,18 @@ function ProjectConversationPageContent() {
 
     const refreshPaperUrl = useCallback(async (paperId: string): Promise<string | null> => {
         try {
-            const response = await fetchFromApi(`/api/projects/papers/${projectId}`);
-            const match = response.papers?.find((p: PaperItem) => p.id === paperId);
-            if (match?.file_url) {
+            const fileUrl = await getProjectPaperFileUrl(projectId, paperId);
+            if (fileUrl) {
                 // Update the papers state so future clicks use the fresh URL
-                setPapers(prev => prev.map(p => p.id === paperId ? { ...p, file_url: match.file_url } : p));
-                return match.file_url;
+                updatePaper(paperId, { file_url: fileUrl });
+                return fileUrl;
             }
             return null;
         } catch (error) {
             console.error("Error refreshing paper URL:", error);
             return null;
         }
-    }, [projectId]);
-
-    useEffect(() => {
-        const fetchPapers = async () => {
-            try {
-                const response = await fetchFromApi(`/api/projects/papers/${projectId}`)
-                const sortedPapers = response.papers.sort((a: PaperItem, b: PaperItem) => {
-                    return new Date(b.created_at || "").getTime() - new Date(a.created_at || "").getTime();
-                });
-                setPapers(sortedPapers)
-            } catch (error) {
-                console.error("Error fetching papers:", error)
-            }
-        }
-
-        if (projectId) {
-            fetchPapers();
-        }
-    }, [projectId])
+    }, [projectId, updatePaper]);
 
     useEffect(() => {
         if (isStreaming) {

--- a/client/src/app/(main)/projects/[projectId]/tables/[tableId]/page.tsx
+++ b/client/src/app/(main)/projects/[projectId]/tables/[tableId]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { PaperItem, DataTableResult } from "@/lib/schema";
+import { DataTableResult } from "@/lib/schema";
 import DataTableGenerationView from "@/components/DataTableGenerationView";
 import { Loader2, ArrowLeft, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -16,7 +16,7 @@ import {
 } from "@/components/ui/breadcrumb";
 import { PdfHighlighterViewer } from "@/components/PdfHighlighterViewer";
 import { useIsMobile } from "@/lib/useMobile";
-import { useProject } from "@/hooks/useProjects";
+import { useProject, useProjectPapers } from "@/hooks/useProjects";
 import { fetchFromApi } from "@/lib/api";
 
 export default function DataTablePage() {
@@ -25,9 +25,10 @@ export default function DataTablePage() {
     const projectId = params.projectId as string;
     const tableId = params.tableId as string;
     const { project } = useProject(projectId);
+    // Papers are loaded with presigned URLs so citation clicks can open the PDF directly.
+    const { papers } = useProjectPapers(projectId, { loadUrls: true });
 
     const [dataTableResult, setDataTableResult] = useState<DataTableResult | null>(null);
-    const [papers, setPapers] = useState<PaperItem[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [pdfUrl, setPdfUrl] = useState<string | null>(null);
@@ -54,22 +55,6 @@ export default function DataTablePage() {
             fetchDataTableResult();
         }
     }, [tableId, fetchDataTableResult]);
-
-    const getProjectPapers = useCallback(async () => {
-        try {
-            const fetchedPapers = await fetchFromApi(`/api/projects/papers/${projectId}`);
-            setPapers(fetchedPapers.papers);
-        } catch (err) {
-            setError("Failed to fetch project papers. Please try again.");
-            console.error(err);
-        }
-    }, [projectId]);
-
-	useEffect(() => {
-		if (projectId) {
-			getProjectPapers();
-		}
-	}, [projectId, getProjectPapers]);
 
     const handleCitationClick = (paperId: string, searchTerm: string) => {
         const paper = papers.find(p => p.id === paperId);

--- a/client/src/app/(main)/understand/page.tsx
+++ b/client/src/app/(main)/understand/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useSubscription, isChatCreditAtLimit } from '@/hooks/useSubscription';
-import { fetchFromApi, fetchStreamFromApi } from '@/lib/api';
+import { fetchFromApi, fetchStreamFromApi, getPaperFileUrl } from '@/lib/api';
 import { useState, useEffect, FormEvent, useRef, useCallback, Suspense, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { usePapers } from '@/hooks/usePapers';
@@ -11,7 +11,6 @@ import { toast } from "sonner";
 
 import {
     ChatMessage,
-    PaperData,
     Reference,
 } from '@/lib/schema';
 import { useAuth } from '@/lib/auth';
@@ -38,7 +37,9 @@ function UnderstandPageContent() {
     const searchParams = useSearchParams();
     const { user, loading: authLoading } = useAuth();
     const [messages, setMessages] = useState<ChatMessage[]>([]);
-    const { papers: fetchedPapers, isLoading: isPapersLoading, error: papersError } = usePapers({ detailed: true });
+    // Paper metadata only — file URLs are fetched lazily per-paper on demand
+    // (via refreshPaperUrl) when a citation/reference is opened.
+    const { papers: fetchedPapers, isLoading: isPapersLoading, error: papersError } = usePapers();
 
     const papers = useMemo(() => {
         if (!fetchedPapers) return [];
@@ -372,8 +373,7 @@ function UnderstandPageContent() {
 
     const refreshPaperUrl = useCallback(async (paperId: string): Promise<string | null> => {
         try {
-            const response: PaperData = await fetchFromApi(`/api/paper?id=${paperId}`);
-            return response.file_url ?? null;
+            return await getPaperFileUrl(paperId);
         } catch (error) {
             console.error('Error refreshing paper URL:', error);
             return null;

--- a/client/src/components/ConversationView.tsx
+++ b/client/src/components/ConversationView.tsx
@@ -130,6 +130,29 @@ export const ConversationView = ({
 		};
 	}, [isStreaming, statusMessageHistory]);
 
+	// Open a paper in the PDF panel. file_url is loaded lazily, so it may be
+	// absent on the paper — fetch a fresh one on demand when that's the case.
+	const openPaperPdf = useCallback(async (paper: PaperItem, searchText: string | null) => {
+		setActivePaperId(paper.id);
+		setPdfTitle(paper.title);
+		setSearchTerm(searchText);
+		setIsPdfVisible(true);
+
+		if (paper.file_url) {
+			setPdfUrl(paper.file_url);
+			return;
+		}
+
+		// Clear any stale PDF from a previously opened paper while we fetch.
+		setPdfUrl(null);
+		if (onRefreshPaperUrl) {
+			const freshUrl = await onRefreshPaperUrl(paper.id);
+			if (freshUrl) {
+				setPdfUrl(freshUrl);
+			}
+		}
+	}, [onRefreshPaperUrl]);
+
 	const handleCitationClick = (key: string, messageIndex: number) => {
 		originalHandleCitationClick(key, messageIndex);
 		const message = messages[messageIndex];
@@ -139,21 +162,15 @@ export const ConversationView = ({
 		if (!citation) return;
 
 		const paper = papers.find(p => p.id === citation.paper_id);
+		if (!paper) return;
 
-		if (paper && paper.file_url) {
-			setPdfUrl(paper.file_url);
-			setPdfTitle(paper.title);
-			setActivePaperId(paper.id);
-
-			// Strip quotes from the reference if wrapped in them
-			let searchText = citation.reference;
-			if ((searchText.startsWith('"') && searchText.endsWith('"')) ||
-				(searchText.startsWith("'") && searchText.endsWith("'"))) {
-				searchText = searchText.substring(1, searchText.length - 1);
-			}
-			setSearchTerm(searchText);
-			setIsPdfVisible(true);
+		// Strip quotes from the reference if wrapped in them
+		let searchText = citation.reference;
+		if ((searchText.startsWith('"') && searchText.endsWith('"')) ||
+			(searchText.startsWith("'") && searchText.endsWith("'"))) {
+			searchText = searchText.substring(1, searchText.length - 1);
 		}
+		openPaperPdf(paper, searchText);
 	};
 
 	const refreshPdfUrl = useCallback(async (): Promise<string | null> => {
@@ -293,13 +310,7 @@ export const ConversationView = ({
 								}
 								onHighlightClear={() => setHighlightedInfo(null)}
 								onPaperClick={(paper) => {
-									if (paper.file_url) {
-										setPdfUrl(paper.file_url);
-										setPdfTitle(paper.title);
-										setActivePaperId(paper.id);
-										setSearchTerm(null);
-										setIsPdfVisible(true);
-									}
+									openPaperPdf(paper, null);
 								}}
 							/>
 						)}

--- a/client/src/components/ProjectPaperPreview.tsx
+++ b/client/src/components/ProjectPaperPreview.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 import { FilePlus2 } from "lucide-react";
 import { PdfHighlighterViewer } from "./PdfHighlighterViewer";
 import { useRouter } from "next/navigation";
-import { fetchFromApi } from "@/lib/api";
+import { fetchFromApi, getProjectPaperFileUrl } from "@/lib/api";
 import { useEffect, useState, useCallback } from "react";
 import { CitePaperButton } from "./CitePaperButton";
 
@@ -39,9 +39,7 @@ export function ProjectPaperPreview({ paper, projectId }: ProjectPaperPreviewPro
 
     const refreshPdfUrl = useCallback(async (): Promise<string | null> => {
         try {
-            const response = await fetchFromApi(`/api/projects/papers/${projectId}`);
-            const match = response.papers?.find((p: PaperItem) => p.id === paper.id);
-            return match?.file_url ?? null;
+            return await getProjectPaperFileUrl(projectId, paper.id);
         } catch (error) {
             console.error("Error refreshing PDF URL:", error);
             return null;

--- a/client/src/components/ReferencePaperCards.tsx
+++ b/client/src/components/ReferencePaperCards.tsx
@@ -74,7 +74,9 @@ export default function ReferencePaperCards({ citations, papers, messageId, mess
                             <div
                                 className="flex-1 min-w-0 cursor-pointer hover:opacity-80 transition-opacity"
                                 onClick={() => {
-                                    if (onPaperClick && paper.file_url) {
+                                    // file_url is loaded lazily by the click handler,
+                                    // so don't gate the click on it being present.
+                                    if (onPaperClick) {
                                         onPaperClick(paper);
                                     }
                                 }}

--- a/client/src/hooks/useProjects.ts
+++ b/client/src/hooks/useProjects.ts
@@ -85,14 +85,29 @@ export function useProject(projectId?: string): UseProjectResult {
     };
 }
 
+interface UseProjectPapersOptions {
+    // Whether the list endpoint should also generate presigned file URLs.
+    // Defaults to false — most consumers only need paper metadata, and URL
+    // generation is expensive. Consumers that need a URL for a single paper
+    // should fetch it lazily via getProjectPaperFileUrl instead.
+    loadUrls?: boolean;
+}
+
 interface UseProjectPapersResult {
     papers: PaperItem[];
     isLoading: boolean;
     error: Error | null;
     refetch: () => Promise<void>;
+    // Locally patch a single paper (e.g. to inject a refreshed file_url)
+    // without refetching the whole list.
+    updatePaper: (paperId: string, patch: Partial<PaperItem>) => void;
 }
 
-export function useProjectPapers(projectId?: string): UseProjectPapersResult {
+export function useProjectPapers(
+    projectId?: string,
+    options?: UseProjectPapersOptions,
+): UseProjectPapersResult {
+    const loadUrls = options?.loadUrls ?? false;
     const [papers, setPapers] = useState<PaperItem[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<Error | null>(null);
@@ -106,7 +121,8 @@ export function useProjectPapers(projectId?: string): UseProjectPapersResult {
         setIsLoading(true);
         setError(null);
         try {
-            const response = await fetchFromApi(`/api/projects/papers/${projectId}`);
+            const query = loadUrls ? "?load_urls=true" : "";
+            const response = await fetchFromApi(`/api/projects/papers/${projectId}${query}`);
             setPapers(response.papers || []);
         } catch (err) {
             setError(err instanceof Error ? err : new Error(`Failed to fetch papers for project ${projectId}`));
@@ -114,17 +130,22 @@ export function useProjectPapers(projectId?: string): UseProjectPapersResult {
         } finally {
             setIsLoading(false);
         }
-    }, [projectId]);
+    }, [projectId, loadUrls]);
 
     useEffect(() => {
         fetchPapers();
     }, [fetchPapers]);
+
+    const updatePaper = useCallback((paperId: string, patch: Partial<PaperItem>) => {
+        setPapers(prev => prev.map(p => (p.id === paperId ? { ...p, ...patch } : p)));
+    }, []);
 
     return {
         papers,
         isLoading,
         error,
         refetch: fetchPapers,
+        updatePaper,
     };
 }
 

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -112,3 +112,13 @@ export async function getProjectPaperFileUrl(
     );
     return response?.file_url ?? null;
 }
+
+/**
+ * Fetch a fresh presigned file URL for a single owned paper. The cheap path
+ * for refreshing an expired URL — avoids the metadata enrichment and full
+ * document payload of GET /api/paper.
+ */
+export async function getPaperFileUrl(paperId: string): Promise<string | null> {
+    const response = await fetchFromApi(`/api/paper/${paperId}/file-url`);
+    return response?.file_url ?? null;
+}

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -96,3 +96,19 @@ export async function fetchStreamFromApi(
 export async function getProjectsForPaper(paperId: string) {
     return fetchFromApi(`/api/projects/papers/from/${paperId}`);
 }
+
+/**
+ * Fetch a fresh presigned file URL for a single paper within a project.
+ * Access is granted via project membership, so this works for collaborators
+ * who don't own the paper. Use this instead of refetching the whole project
+ * paper list just to refresh one URL.
+ */
+export async function getProjectPaperFileUrl(
+    projectId: string,
+    paperId: string,
+): Promise<string | null> {
+    const response = await fetchFromApi(
+        `/api/projects/papers/${projectId}/${paperId}/file-url`,
+    );
+    return response?.file_url ?? null;
+}

--- a/server/app/api/paper_api.py
+++ b/server/app/api/paper_api.py
@@ -147,6 +147,35 @@ async def get_active_paper_ids(
     )
 
 
+@paper_router.get("/{id}/file-url")
+async def get_paper_file_url(
+    id: str,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_required_user),
+) -> JSONResponse:
+    """
+    Get a fresh presigned file URL for a single owned paper.
+
+    This is the cheap path for "my URL expired, give me a fresh one" — it
+    avoids the metadata enrichment and full document payload (raw_content,
+    etc.) that GET /api/paper returns.
+    """
+    paper = paper_crud.get(db, id=id, user=current_user)
+    if not paper:
+        return JSONResponse(status_code=404, content={"message": "Document not found"})
+
+    file_url = s3_service.get_cached_presigned_url(
+        db,
+        paper_id=str(paper.id),
+        object_key=str(paper.s3_object_key),
+        current_user=current_user,
+    )
+    if not file_url:
+        return JSONResponse(status_code=404, content={"message": "File not found"})
+
+    return JSONResponse(status_code=200, content={"file_url": file_url})
+
+
 @paper_router.get("/note")
 async def get_paper_note(
     paper_id: str,

--- a/server/app/api/projects/project_papers_api.py
+++ b/server/app/api/projects/project_papers_api.py
@@ -214,20 +214,31 @@ async def add_paper_to_project(
 @project_papers_router.get("/{project_id}")
 async def get_project_papers(
     project_id: str,
+    load_urls: bool = False,
     db: Session = Depends(get_db),
     current_user: CurrentUser = Depends(get_required_user),
 ) -> JSONResponse:
-    """Get all papers for a specific project"""
+    """
+    Get all papers for a specific project.
+
+    Presigned file URLs are only generated when ``load_urls=true``. Most
+    callers (e.g. the project overview page) just need paper metadata, and
+    generating URLs for every paper is expensive on cache expiry. Callers
+    that need a URL for a single paper should use the
+    ``/{project_id}/{paper_id}/file-url`` endpoint instead.
+    """
     try:
         papers = project_paper_crud.get_papers_metadata_by_project_id(
             db, project_id=uuid.UUID(project_id), user=current_user
         )
 
-        # Bulk retrieve presigned URLs for all papers (optimized with parallelization)
-        file_urls = s3_service.get_cached_presigned_urls_bulk(
-            db=db,
-            papers=papers,
-        )
+        file_urls: dict = {}
+        if load_urls:
+            # Bulk retrieve presigned URLs (optimized with parallelization)
+            file_urls = s3_service.get_cached_presigned_urls_bulk(
+                db=db,
+                papers=papers,
+            )
 
         return JSONResponse(
             status_code=200,

--- a/server/app/api/projects/project_papers_api.py
+++ b/server/app/api/projects/project_papers_api.py
@@ -264,6 +264,62 @@ async def get_project_papers(
         )
 
 
+@project_papers_router.get("/{project_id}/{paper_id}/file-url")
+async def get_project_paper_file_url(
+    project_id: str,
+    paper_id: str,
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_required_user),
+) -> JSONResponse:
+    """
+    Get a presigned file URL for a single paper within a project.
+
+    Access is granted via project membership rather than paper ownership, so
+    collaborators can open papers they don't own. This is the cheap path for
+    "my URL expired, give me a fresh one" — callers should use this instead
+    of refetching the whole project paper list.
+    """
+    try:
+        paper = project_paper_crud.get_paper_by_project(
+            db,
+            paper_id=uuid.UUID(paper_id),
+            project_id=uuid.UUID(project_id),
+            user=current_user,
+        )
+
+        if not paper:
+            raise HTTPException(
+                status_code=404,
+                detail="Paper not found in the specified project or user does not have access.",
+            )
+
+        # The paper may be owned by another collaborator, so resolve the URL
+        # against the paper's owner rather than the current user.
+        file_url = s3_service.get_cached_presigned_url_by_owner(
+            db,
+            paper_id=str(paper.id),
+            object_key=str(paper.s3_object_key),
+            owner_id=str(paper.user_id),
+        )
+
+        if not file_url:
+            raise HTTPException(status_code=404, detail="File not found")
+
+        return JSONResponse(
+            status_code=200,
+            content={"file_url": file_url},
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error fetching project paper file URL: {e}", exc_info=True)
+        return JSONResponse(
+            status_code=400,
+            content={"message": "Failed to fetch project paper file URL"},
+        )
+
+
 @project_papers_router.get("/from/{paper_id}")
 async def get_projects_from_paper_id(
     paper_id: str,

--- a/server/app/database/crud/paper_crud.py
+++ b/server/app/database/crud/paper_crud.py
@@ -24,7 +24,7 @@ from app.schemas.responses import PaperMetadataExtraction, ResponseCitation
 from app.schemas.user import CurrentUser
 from pydantic import BaseModel
 from sqlalchemy import func, text
-from sqlalchemy.orm import Session, selectinload
+from sqlalchemy.orm import Session, load_only, selectinload
 
 logger = logging.getLogger(__name__)
 
@@ -288,7 +288,27 @@ class PaperCRUD(CRUDBase["Paper", PaperCreate, PaperUpdate]):
         """
         return (
             db.query(Paper)
-            .options(selectinload(Paper.tags))
+            .options(
+                selectinload(Paper.tags),
+                # Library listings only need lightweight metadata. Without this,
+                # the query SELECT *'s heavy columns (raw_content, ts_vector,
+                # summary, summary_citations, page_offset_map) for every paper
+                # in the user's library. Both callers (/api/paper/all and
+                # /api/paper/active) serialize only the columns listed here.
+                load_only(
+                    Paper.title,
+                    Paper.created_at,
+                    Paper.updated_at,
+                    Paper.abstract,
+                    Paper.authors,
+                    Paper.institutions,
+                    Paper.keywords,
+                    Paper.status,
+                    Paper.preview_url,
+                    Paper.size_in_kb,
+                    Paper.publish_date,
+                ),
+            )
             .outerjoin(PaperUploadJob, Paper.upload_job_id == PaperUploadJob.id)
             .filter(
                 Paper.user_id == user.id,


### PR DESCRIPTION
There were a couple of issues with how we were loading papers per project. Some fixes include:
- Don't prefetch signed file urls for pages that don't need them (e.g., the project page)
- Expose a `load_url` parameter to decide at request time whether or not to get the papers
- Use a common hook that shares data for project papers. Expose a mutation method to update papers.
- Create new API for fetching a fully hydrated paper specific to a project