### PR TITLE
Refine sidebar menu states and account popover

### DIFF
--- a/client/src/components/CollapsibleSidebarMenu.tsx
+++ b/client/src/components/CollapsibleSidebarMenu.tsx
@@ -39,8 +39,10 @@ export function CollapsibleSidebarMenu<T extends { id: string; title?: string; }
     maxItems = 7,
     tag,
 }: CollapsibleSidebarMenuProps<T>) {
+    const hasSubItems = items.length > 0;
+
     return (
-        <Collapsible asChild defaultOpen={defaultOpen} className="group/collapsible">
+        <Collapsible asChild defaultOpen={defaultOpen && hasSubItems} className="group/collapsible">
             <SidebarMenuItem>
                 <div className="flex items-center w-full">
                     <Link href={url} className="flex items-center flex-1" onClick={(e: React.MouseEvent) => e.stopPropagation()}>
@@ -55,33 +57,38 @@ export function CollapsibleSidebarMenu<T extends { id: string; title?: string; }
                         </SidebarMenuButton>
                     </Link>
                     <CollapsibleTrigger asChild>
-                        <button className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded">
+                        <button
+                            className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded disabled:text-muted-foreground/40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+                            disabled={!hasSubItems}
+                        >
                             <ChevronDown className="h-4 w-4 transition-transform duration-200 group-data-[state=open]/collapsible:rotate-180" />
                         </button>
                     </CollapsibleTrigger>
                 </div>
-                <CollapsibleContent>
-                    <SidebarMenuSub>
-                        {items.slice(0, maxItems).map((item) => (
-                            <SidebarMenuSubItem key={item.id}>
-                                <SidebarMenuSubButton asChild>
-                                    <Link href={getItemUrl(item)} className="text-xs font-medium w-full h-fit my-1">
-                                        <p className="line-clamp-3">{getItemName ? getItemName(item) : item.title}</p>
-                                    </Link>
-                                </SidebarMenuSubButton>
-                            </SidebarMenuSubItem>
-                        ))}
-                        {items.length > maxItems && (
-                            <SidebarMenuSubItem>
-                                <SidebarMenuSubButton asChild>
-                                    <Link href={viewAllUrl} className="text-xs font-medium h-fit my-1">
-                                        {viewAllText} <ArrowRight className="inline h-3 w-3 ml-1" />
-                                    </Link>
-                                </SidebarMenuSubButton>
-                            </SidebarMenuSubItem>
-                        )}
-                    </SidebarMenuSub>
-                </CollapsibleContent>
+                {hasSubItems && (
+                    <CollapsibleContent>
+                        <SidebarMenuSub>
+                            {items.slice(0, maxItems).map((item) => (
+                                <SidebarMenuSubItem key={item.id}>
+                                    <SidebarMenuSubButton asChild>
+                                        <Link href={getItemUrl(item)} className="text-xs font-medium w-full h-fit my-1">
+                                            <p className="line-clamp-3">{getItemName ? getItemName(item) : item.title}</p>
+                                        </Link>
+                                    </SidebarMenuSubButton>
+                                </SidebarMenuSubItem>
+                            ))}
+                            {items.length > maxItems && (
+                                <SidebarMenuSubItem>
+                                    <SidebarMenuSubButton asChild>
+                                        <Link href={viewAllUrl} className="text-xs font-medium h-fit my-1">
+                                            {viewAllText} <ArrowRight className="inline h-3 w-3 ml-1" />
+                                        </Link>
+                                    </SidebarMenuSubButton>
+                                </SidebarMenuSubItem>
+                            )}
+                        </SidebarMenuSub>
+                    </CollapsibleContent>
+                )}
             </SidebarMenuItem>
         </Collapsible>
     );

--- a/client/src/components/sidebar/SidebarFooter.tsx
+++ b/client/src/components/sidebar/SidebarFooter.tsx
@@ -7,7 +7,6 @@ import {
     SidebarMenuButton,
     SidebarMenuItem,
 } from "@/components/ui/sidebar";
-import { Avatar } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -23,7 +22,7 @@ import {
 } from "@/components/ui/sheet";
 import { User } from "@/lib/auth";
 import { SubscriptionData } from "@/lib/schema";
-import { UserMenuContent } from "./UserMenuContent";
+import { UserAvatar, UserMenuContent } from "./UserMenuContent";
 import { UsageLimitCard } from "./UsageLimitCard";
 import { ReferralEntry } from "./referralEntry";
 import { SubscriptionWarning } from "./subscriptionWarning";
@@ -117,10 +116,7 @@ export function AppSidebarFooter({
                             <SheetTrigger asChild>
                                 <SidebarMenuButton className="flex items-center gap-2">
                                     <span className="flex min-w-0 flex-1 items-center gap-2">
-                                        <Avatar className="h-6 w-6 shrink-0">
-                                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                                            {user.picture ? <img src={user.picture} alt={user.name || user.email} /> : <UserIcon size={16} />}
-                                        </Avatar>
+                                        <UserAvatar user={user} className="h-6 w-6 shrink-0" iconSize={16} />
                                         <span className="truncate">{user.name || user.email}</span>
                                     </span>
                                     <ChevronsUpDown className="h-4 w-4 shrink-0" />
@@ -135,10 +131,7 @@ export function AppSidebarFooter({
                             <PopoverTrigger asChild>
                                 <SidebarMenuButton className="flex items-center gap-2">
                                     <span className="flex min-w-0 flex-1 items-center gap-2">
-                                        <Avatar className="h-6 w-6 shrink-0">
-                                            {/* eslint-disable-next-line @next/next/no-img-element */}
-                                            {user.picture ? (<img src={user.picture} alt={user.name || user.email} />) : (<UserIcon size={16} />)}
-                                        </Avatar>
+                                        <UserAvatar user={user} className="h-6 w-6 shrink-0" iconSize={16} />
                                         <span className="truncate">{user.name || user.email}</span>
                                     </span>
                                     <ChevronsUpDown className="h-4 w-4 shrink-0" />

--- a/client/src/components/sidebar/SidebarFooter.tsx
+++ b/client/src/components/sidebar/SidebarFooter.tsx
@@ -116,14 +116,14 @@ export function AppSidebarFooter({
                         <Sheet>
                             <SheetTrigger asChild>
                                 <SidebarMenuButton className="flex items-center gap-2">
-                                    <span className="flex items-center gap-2 truncate">
-                                        <Avatar className="h-6 w-6">
+                                    <span className="flex min-w-0 flex-1 items-center gap-2">
+                                        <Avatar className="h-6 w-6 shrink-0">
                                             {/* eslint-disable-next-line @next/next/no-img-element */}
                                             {user.picture ? <img src={user.picture} alt={user.name || user.email} /> : <UserIcon size={16} />}
                                         </Avatar>
                                         <span className="truncate">{user.name || user.email}</span>
                                     </span>
-                                    <ChevronsUpDown className="h-4 w-4 ml-auto" />
+                                    <ChevronsUpDown className="h-4 w-4 shrink-0" />
                                 </SidebarMenuButton>
                             </SheetTrigger>
                             <SheetContent side="bottom">
@@ -134,14 +134,14 @@ export function AppSidebarFooter({
                         <Popover>
                             <PopoverTrigger asChild>
                                 <SidebarMenuButton className="flex items-center gap-2">
-                                    <span className="flex items-center gap-2 truncate">
-                                        <Avatar className="h-6 w-6">
+                                    <span className="flex min-w-0 flex-1 items-center gap-2">
+                                        <Avatar className="h-6 w-6 shrink-0">
                                             {/* eslint-disable-next-line @next/next/no-img-element */}
                                             {user.picture ? (<img src={user.picture} alt={user.name || user.email} />) : (<UserIcon size={16} />)}
                                         </Avatar>
                                         <span className="truncate">{user.name || user.email}</span>
                                     </span>
-                                    <ChevronsUpDown className="h-4 w-4 ml-auto" />
+                                    <ChevronsUpDown className="h-4 w-4 shrink-0" />
                                 </SidebarMenuButton>
                             </PopoverTrigger>
                             <PopoverContent className="w-60 p-1" align="start">

--- a/client/src/components/sidebar/UserMenuContent.tsx
+++ b/client/src/components/sidebar/UserMenuContent.tsx
@@ -11,7 +11,7 @@ import {
     Sun,
     User as UserIcon,
 } from "lucide-react";
-import { Avatar } from "@/components/ui/avatar";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
 import {
     Tooltip,
@@ -19,7 +19,21 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { User } from "@/lib/auth";
+import { getAlphaHashToBackgroundColor, getInitials } from "@/lib/utils";
 import { ReferralEntry } from "./referralEntry";
+
+export const UserAvatar = ({ user, className, iconSize }: { user: User, className: string, iconSize: number }) => {
+    const displayName = user.name || user.email;
+
+    return (
+        <Avatar className={className}>
+            {user.picture && <AvatarImage src={user.picture} alt={displayName || "User"} />}
+            <AvatarFallback className={displayName ? getAlphaHashToBackgroundColor(displayName) : "bg-muted text-muted-foreground"}>
+                {displayName ? getInitials(displayName) : <UserIcon size={iconSize} />}
+            </AvatarFallback>
+        </Avatar>
+    );
+};
 
 export const UserMenuContent = ({
     user,
@@ -36,10 +50,7 @@ export const UserMenuContent = ({
 }) => (
     <div className="flex flex-col gap-1">
         <div className="flex items-center gap-3 p-3">
-            <Avatar className="h-10 w-10 shrink-0">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                {user.picture ? (<img src={user.picture} alt={user.name || user.email} />) : (<UserIcon size={24} />)}
-            </Avatar>
+            <UserAvatar user={user} className="h-10 w-10 shrink-0" iconSize={24} />
             <div className="min-w-0 flex-1">
                 <Tooltip>
                     <TooltipTrigger asChild>

--- a/client/src/components/sidebar/UserMenuContent.tsx
+++ b/client/src/components/sidebar/UserMenuContent.tsx
@@ -13,6 +13,11 @@ import {
 } from "lucide-react";
 import { Avatar } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { User } from "@/lib/auth";
 import { ReferralEntry } from "./referralEntry";
 
@@ -31,13 +36,27 @@ export const UserMenuContent = ({
 }) => (
     <div className="flex flex-col gap-1">
         <div className="flex items-center gap-3 p-3">
-            <Avatar className="h-10 w-10">
+            <Avatar className="h-10 w-10 shrink-0">
                 {/* eslint-disable-next-line @next/next/no-img-element */}
                 {user.picture ? (<img src={user.picture} alt={user.name || user.email} />) : (<UserIcon size={24} />)}
             </Avatar>
-            <div>
-                <h3 className="font-medium">{user.name || user.email}</h3>
-                <p className="text-sm text-muted-foreground">{user.email}</p>
+            <div className="min-w-0 flex-1">
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <h3 className="truncate font-medium">{user.name || user.email}</h3>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" align="start" className="max-w-72 break-words text-left">
+                        {user.name || user.email}
+                    </TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <p className="truncate text-sm text-muted-foreground">{user.email}</p>
+                    </TooltipTrigger>
+                    <TooltipContent side="top" align="start" className="max-w-72 break-words text-left">
+                        {user.email}
+                    </TooltipContent>
+                </Tooltip>
             </div>
         </div>
         <Link href="/settings" className="w-full">


### PR DESCRIPTION
## Summary
- constrain the signed-in account menu so long names and emails truncate cleanly
- show tooltips for truncated account name and email in the opened user menu
- keep account menu avatars from shrinking when text is long
- disable sidebar section toggles when Library, Projects, or Ask have no subitems

## Context
This addresses the accepted UI follow-ups from #57. The privacy-warning item is intentionally left out because the issue discussion confirmed it was caused by local setup rather than the app itself.

## Testing
- `npx tsc --noEmit --pretty false`
- `git diff upstream/master...HEAD --check`

## Notes
I cleared the generated `.next` cache before running TypeScript because stale generated route types referenced files moved on the latest upstream branch.
