### PR TITLE
feat: implement @-mention UI to scope queries to specific papers or e…

### DIFF
--- a/client/src/app/(main)/(protected)/understand/page.tsx
+++ b/client/src/app/(main)/(protected)/understand/page.tsx
@@ -14,6 +14,7 @@ import {
     CitationArtifact,
     MessageTrace,
     Reference,
+    ScopeItem,
 } from '@/lib/schema';
 import { useAuth } from '@/lib/auth';
 
@@ -71,6 +72,8 @@ function UnderstandPageContent() {
     const [statusMessage, setStatusMessage] = useState('');
 
     const [isSessionLoading, setIsSessionLoading] = useState(true);
+
+    const [scope, setScope] = useState<ScopeItem[]>([]);
 
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const inputMessageRef = useRef<HTMLTextAreaElement>(null);
@@ -252,9 +255,10 @@ function UnderstandPageContent() {
             }
         }
 
-        const requestBody: ChatRequestBody = {
+        const requestBody: ChatRequestBody & { scope?: ScopeItem[] } = {
             user_query: userMessage.content,
             conversation_id: currentConversationId,
+            scope: scope.length > 0 ? scope : undefined,
         };
 
         try {
@@ -416,6 +420,8 @@ function UnderstandPageContent() {
                 setHighlightedInfo={setHighlightedInfo}
                 authLoading={authLoading}
                 onRefreshPaperUrl={refreshPaperUrl}
+                scope={scope}
+                onScopeChange={setScope}
             />
         </div>
     );

--- a/client/src/components/AtMentionDropdown.tsx
+++ b/client/src/components/AtMentionDropdown.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useState, useEffect, useRef, useCallback } from "react";
+import { FileText, FolderKanban, Highlighter, Loader2 } from "lucide-react";
+import { fetchFromApi } from "@/lib/api";
+import { ScopeItem, MentionResult } from "@/lib/schema";
+
+interface AtMentionDropdownProps {
+    isOpen: boolean;
+    searchTerm: string;
+    anchorRect: DOMRect | null;
+    onSelect: (item: ScopeItem) => void;
+    onClose: () => void;
+}
+
+type SectionKey = "papers" | "projects" | "highlights" | "comments";
+
+const SECTION_ICONS: Record<SectionKey, React.ReactNode> = {
+    papers: <FileText className="h-4 w-4 text-blue-500 flex-shrink-0" />,
+    projects: <FolderKanban className="h-4 w-4 text-primary flex-shrink-0" />,
+    highlights: <Highlighter className="h-4 w-4 text-yellow-500 flex-shrink-0" />,
+    comments: <Highlighter className="h-4 w-4 text-green-500 flex-shrink-0" />,
+};
+
+const SECTION_LABELS: Record<SectionKey, string> = {
+    papers: "Papers",
+    projects: "Projects",
+    highlights: "Highlights",
+    comments: "Comments",
+};
+
+export function AtMentionDropdown({
+    isOpen,
+    searchTerm,
+    anchorRect,
+    onSelect,
+    onClose,
+}: AtMentionDropdownProps) {
+    const [results, setResults] = useState<MentionResult | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [selectedIndex, setSelectedIndex] = useState(0);
+    const dropdownRef = useRef<HTMLDivElement>(null);
+    const abortRef = useRef<AbortController | null>(null);
+
+    // Build a flat list of all items with their section
+    const flatItems = useCallback(() => {
+        if (!results) return [] as { item: ScopeItem; section: SectionKey }[];
+        const items: { item: ScopeItem; section: SectionKey }[] = [];
+        for (const section of ["papers", "projects", "highlights", "comments"] as SectionKey[]) {
+            for (const item of results[section] || []) {
+                items.push({ item, section });
+            }
+        }
+        return items;
+    }, [results]);
+
+    // Fetch results with debounce
+    useEffect(() => {
+        if (!isOpen || !searchTerm.trim()) {
+            setResults(null);
+            setError(null);
+            return;
+        }
+
+        if (abortRef.current) {
+            abortRef.current.abort();
+        }
+
+        const controller = new AbortController();
+        abortRef.current = controller;
+        setIsLoading(true);
+        setError(null);
+
+        const timeout = setTimeout(async () => {
+            try {
+                const data: MentionResult = await fetchFromApi(
+                    `/api/search/mentions?q=${encodeURIComponent(searchTerm)}&limit=5`,
+                    { signal: controller.signal }
+                );
+                if (controller.signal.aborted) return;
+                setResults(data);
+            } catch (err) {
+                if (err instanceof Error && err.name === "AbortError") return;
+                setError("Could not load suggestions");
+                setResults(null);
+            } finally {
+                if (!controller.signal.aborted) {
+                    setIsLoading(false);
+                }
+            }
+        }, 300);
+
+        return () => {
+            clearTimeout(timeout);
+            controller.abort();
+        };
+    }, [isOpen, searchTerm]);
+
+    // Reset selected index when results change
+    useEffect(() => {
+        setSelectedIndex(0);
+    }, [results]);
+
+    // Handle keyboard navigation
+    const handleKeyDown = useCallback(
+        (e: KeyboardEvent) => {
+            if (!isOpen) return;
+            const items = flatItems();
+            if (items.length === 0) return;
+
+            switch (e.key) {
+                case "ArrowDown":
+                    e.preventDefault();
+                    setSelectedIndex((prev) => (prev < items.length - 1 ? prev + 1 : 0));
+                    break;
+                case "ArrowUp":
+                    e.preventDefault();
+                    setSelectedIndex((prev) => (prev > 0 ? prev - 1 : items.length - 1));
+                    break;
+                case "Enter":
+                    e.preventDefault();
+                    if (items[selectedIndex]) {
+                        onSelect(items[selectedIndex].item);
+                        onClose();
+                    }
+                    break;
+                case "Escape":
+                    e.preventDefault();
+                    onClose();
+                    break;
+            }
+        },
+        [isOpen, flatItems, selectedIndex, onSelect, onClose]
+    );
+
+    useEffect(() => {
+        document.addEventListener("keydown", handleKeyDown);
+        return () => document.removeEventListener("keydown", handleKeyDown);
+    }, [handleKeyDown]);
+
+    // Scroll selected item into view
+    useEffect(() => {
+        if (dropdownRef.current && selectedIndex >= 0) {
+            const el = dropdownRef.current.querySelector(`[data-index="${selectedIndex}"]`);
+            el?.scrollIntoView({ block: "nearest" });
+        }
+    }, [selectedIndex]);
+
+    if (!isOpen) return null;
+
+    const items = flatItems();
+    const hasItems = items.length > 0;
+    const hasResults = results !== null;
+    const isEmptySearch = hasResults && !hasItems && !isLoading;
+
+    // Build sections for rendering (with section headers)
+    const sections = (["papers", "projects", "highlights", "comments"] as SectionKey[])
+        .filter((s) => (results?.[s]?.length ?? 0) > 0)
+        .map((section) => ({
+            section,
+            items: (results?.[section] || []).map((item) => item),
+        }));
+
+    // Calculate position
+    const style: React.CSSProperties = {};
+    if (anchorRect) {
+        style.position = "fixed";
+        style.left = `${anchorRect.left}px`;
+        style.top = `${anchorRect.bottom + 4}px`;
+        style.width = `${Math.max(anchorRect.width, 320)}px`;
+    }
+
+    return (
+        <div
+            ref={dropdownRef}
+            role="listbox"
+            aria-label="Search results"
+            style={style}
+            className="z-50 bg-background border rounded-xl shadow-lg overflow-hidden max-h-[360px] flex flex-col"
+            onMouseDown={(e) => e.preventDefault()}
+        >
+            {isLoading && (
+                <div className="flex items-center gap-2 px-4 py-3 text-muted-foreground">
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    <span className="text-sm">Searching...</span>
+                </div>
+            )}
+
+            {error && (
+                <div className="px-4 py-3 text-sm text-red-500">
+                    {error}
+                </div>
+            )}
+
+            {isEmptySearch && (
+                <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+                    No results found for &ldquo;{searchTerm}&rdquo;
+                </div>
+            )}
+
+            {hasItems && !isLoading && (
+                <div className="overflow-y-auto">
+                    {sections.map(({ section, items: sectionItems }) => (
+                        <div key={section}>
+                            <p className="px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wide bg-muted/30">
+                                {SECTION_LABELS[section]}
+                            </p>
+                            {sectionItems.map((item, idx) => {
+                                const globalIdx = items.findIndex(
+                                    (fi) => fi.item.id === item.id && fi.section === section
+                                );
+                                return (
+                                    <button
+                                        key={`${section}-${item.id}`}
+                                        data-index={globalIdx}
+                                        role="option"
+                                        aria-selected={selectedIndex === globalIdx}
+                                        onMouseEnter={() => setSelectedIndex(globalIdx)}
+                                        onClick={() => {
+                                            onSelect(item);
+                                            onClose();
+                                        }}
+                                        className={`w-full flex items-center gap-3 px-3 py-2.5 text-left transition-colors ${selectedIndex === globalIdx ? "bg-accent" : "hover:bg-accent"
+                                            }`}
+                                    >
+                                        {SECTION_ICONS[section]}
+                                        <div className="min-w-0 flex-1">
+                                            <p className="text-sm font-medium truncate">
+                                                {item.label}
+                                            </p>
+                                            {item.subtitle && (
+                                                <p className="text-xs text-muted-foreground truncate">
+                                                    {item.subtitle}
+                                                </p>
+                                            )}
+                                        </div>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/client/src/components/ConversationView.tsx
+++ b/client/src/components/ConversationView.tsx
@@ -20,7 +20,9 @@ import {
 	DialogTitle,
 } from "@/components/ui/dialog";
 import { ChatMessageActions } from "@/components/ChatMessageActions";
-import { ChatMessage, Reference, PaperItem, CitationArtifact } from "@/lib/schema";
+import { ChatMessage, Reference, PaperItem, CitationArtifact, ScopeItem, MentionResult } from "@/lib/schema";
+import { AtMentionDropdown } from "@/components/AtMentionDropdown";
+import { ScopeChips } from "@/components/ScopeChips";
 import ReferencePaperCards from "@/components/ReferencePaperCards";
 import { CitationArtifactCard } from "@/components/CitationArtifactCard";
 import { MessageTraceViewer } from "@/components/MessageTraceViewer";
@@ -54,8 +56,10 @@ interface ConversationViewProps {
 	handleCitationClick: (key: string, messageIndex: number) => void;
 	highlightedInfo: { paperId: string; messageIndex: number } | null;
 	setHighlightedInfo: (info: { paperId: string; messageIndex: number } | null) => void;
-	authLoading: boolean;
-	onRefreshPaperUrl?: (paperId: string) => Promise<string | null>;
+    authLoading: boolean;
+    onRefreshPaperUrl?: (paperId: string) => Promise<string | null>;
+    scope?: ScopeItem[];
+    onScopeChange?: (scope: ScopeItem[]) => void;
 }
 
 export const ConversationView = ({
@@ -82,8 +86,10 @@ export const ConversationView = ({
 	handleCitationClick: originalHandleCitationClick,
 	highlightedInfo,
 	setHighlightedInfo,
-	authLoading,
-	onRefreshPaperUrl,
+    authLoading,
+    onRefreshPaperUrl,
+    scope = [],
+    onScopeChange,
 }: ConversationViewProps) => {
 	const messagesContainerRef = useRef<HTMLDivElement>(null);
 	const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -98,9 +104,15 @@ export const ConversationView = ({
 	const [collapsedReferences, setCollapsedReferences] = useState<Set<number>>(new Set());
 	const isMobile = useIsMobile();
 
-	const [statusMessageHistory, setStatusMessageHistory] = useState<{ message: string; startTime: number }[]>([]);
-	const [elapsedTime, setElapsedTime] = useState(0);
-	const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+    const [statusMessageHistory, setStatusMessageHistory] = useState<{ message: string; startTime: number }[]>([]);
+    const [elapsedTime, setElapsedTime] = useState(0);
+    const [isHistoryOpen, setIsHistoryOpen] = useState(false);
+
+    // @-mention state
+    const [isMentionOpen, setIsMentionOpen] = useState(false);
+    const [mentionSearchTerm, setMentionSearchTerm] = useState("");
+    const [mentionAnchorRect, setMentionAnchorRect] = useState<DOMRect | null>(null);
+    const mentionInputRef = useRef<HTMLTextAreaElement>(null);
 
 	useEffect(() => {
 		if (statusMessage && (statusMessageHistory.length === 0 || statusMessageHistory[statusMessageHistory.length - 1].message !== statusMessage)) {
@@ -198,14 +210,73 @@ export const ConversationView = ({
 		});
 	}, []);
 
-	const handleTextareaChange = useCallback(
-		(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-			onCurrentMessageChange(e.target.value);
-		},
-		[onCurrentMessageChange]
-	);
+    const handleTextareaChange = useCallback(
+        (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+            const value = e.target.value;
+            onCurrentMessageChange(value);
 
-	const handleNewSubmit = useCallback(
+            // Detect @-mention
+            const lastAtIndex = value.lastIndexOf("@");
+            if (lastAtIndex !== -1) {
+                const afterAt = value.slice(lastAtIndex + 1);
+                if (!afterAt.startsWith(" ") && afterAt.length > 0) {
+                    const spaceIndex = afterAt.indexOf(" ");
+                    const term = spaceIndex === -1 ? afterAt : afterAt.slice(0, spaceIndex);
+                    setMentionSearchTerm(term);
+                    setIsMentionOpen(true);
+                    // Position dropdown below the textarea
+                    const textarea = mentionInputRef.current;
+                    if (textarea) {
+                        const rect = textarea.getBoundingClientRect();
+                        setMentionAnchorRect(rect);
+                    }
+                    return;
+                }
+            }
+            setIsMentionOpen(false);
+            setMentionSearchTerm("");
+        },
+        [onCurrentMessageChange]
+    );
+
+    const handleMentionSelect = useCallback(
+        (item: ScopeItem) => {
+            // Remove the @mention text from the input
+            const lastAtIndex = currentMessage.lastIndexOf("@");
+            if (lastAtIndex !== -1) {
+                const afterAt = currentMessage.slice(lastAtIndex + 1);
+                const spaceIndex = afterAt.indexOf(" ");
+                const termLength = spaceIndex === -1 ? afterAt.length : spaceIndex;
+                const before = currentMessage.slice(0, lastAtIndex);
+                const after = currentMessage.slice(lastAtIndex + 1 + termLength);
+                const newValue = (before + after).replace(/  +/g, " ").trim();
+                onCurrentMessageChange(newValue);
+            }
+            // Add to scope
+            if (onScopeChange) {
+                onScopeChange([...scope, item]);
+            }
+            setIsMentionOpen(false);
+            setMentionSearchTerm("");
+        },
+        [currentMessage, onCurrentMessageChange, onScopeChange, scope]
+    );
+
+    const handleMentionClose = useCallback(() => {
+        setIsMentionOpen(false);
+        setMentionSearchTerm("");
+    }, []);
+
+    const handleRemoveScope = useCallback(
+        (id: string) => {
+            if (onScopeChange) {
+                onScopeChange(scope.filter((s) => s.id !== id));
+            }
+        },
+        [onScopeChange, scope]
+    );
+
+    const handleNewSubmit = useCallback(
 		async (e: FormEvent | null = null) => {
 			if (e) {
 				e.preventDefault();
@@ -487,27 +558,49 @@ export const ConversationView = ({
 							What would you like to discover in your papers?
 						</AnimatedGradientText>
 					)}
-					<form onSubmit={handleNewSubmit} className="w-full transition-all duration-300 ease-in-out" ref={chatInputFormRef}>
-						<div className="relative w-full transition-all duration-300 ease-in-out">
-							<Textarea
-								value={currentMessage}
-								onChange={handleTextareaChange}
-								ref={inputMessageRef}
-								autoFocus
-								placeholder={
-									isCentered
-										? "Look for a specific citation. Find a relevant paper. Collate evidence across your library."
-										: "Ask a follow-up"
-								}
-								className="min-h-20 resize-none pr-12 w-full border-none dark:border-none focus-visible:ring-1 focus-visible:ring-blue-400/30 bg-secondary dark:bg-accent text-primary"
-								disabled={isStreaming || (!isPapersLoading && papers.length === 0) || chatCreditLimitReached || !isOwner}
-								onKeyDown={(e) => {
-									if (e.key === "Enter" && !e.shiftKey) {
-										e.preventDefault();
-										handleNewSubmit(e);
-									}
-								}}
-							/>
+                    <form onSubmit={handleNewSubmit} className="w-full transition-all duration-300 ease-in-out" ref={chatInputFormRef}>
+                        <div className="relative w-full transition-all duration-300 ease-in-out">
+                            <ScopeChips items={scope} onRemove={handleRemoveScope} />
+                            <Textarea
+                                value={currentMessage}
+                                onChange={handleTextareaChange}
+                                ref={(el) => {
+                                    inputMessageRef.current = el;
+                                    mentionInputRef.current = el;
+                                }}
+                                autoFocus
+                                placeholder={
+                                    isCentered
+                                        ? "Look for a specific citation. Find a relevant paper. Collate evidence across your library."
+                                        : "Ask a follow-up"
+                                }
+                                className="min-h-20 resize-none pr-12 w-full border-none dark:border-none focus-visible:ring-1 focus-visible:ring-blue-400/30 bg-secondary dark:bg-accent text-primary"
+                                disabled={isStreaming || (!isPapersLoading && papers.length === 0) || chatCreditLimitReached || !isOwner}
+                                onKeyDown={(e) => {
+                                    if (isMentionOpen) {
+                                        if (e.key === "Enter" && !e.shiftKey) {
+                                            e.preventDefault();
+                                            // Let the dropdown handle selection
+                                            return;
+                                        }
+                                        if (e.key === "Escape") {
+                                            handleMentionClose();
+                                        }
+                                        return;
+                                    }
+                                    if (e.key === "Enter" && !e.shiftKey) {
+                                        e.preventDefault();
+                                        handleNewSubmit(e);
+                                    }
+                                }}
+                            />
+                            <AtMentionDropdown
+                                isOpen={isMentionOpen}
+                                searchTerm={mentionSearchTerm}
+                                anchorRect={mentionAnchorRect}
+                                onSelect={handleMentionSelect}
+                                onClose={handleMentionClose}
+                            />
 							<Button
 								type="submit"
 								size="sm"

--- a/client/src/components/ScopeChips.tsx
+++ b/client/src/components/ScopeChips.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { X, FileText, FolderKanban } from "lucide-react";
+import { ScopeItem } from "@/lib/schema";
+
+interface ScopeChipsProps {
+    items: ScopeItem[];
+    onRemove: (id: string) => void;
+}
+
+const SCOPE_ICONS: Record<string, React.ReactNode> = {
+    paper: <FileText className="h-3 w-3" />,
+    project: <FolderKanban className="h-3 w-3" />,
+};
+
+const SCOPE_COLORS: Record<string, string> = {
+    paper: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300 border-blue-200 dark:border-blue-800",
+    project: "bg-primary/10 text-primary dark:bg-primary/20 border-primary/20",
+};
+
+export function ScopeChips({ items, onRemove }: ScopeChipsProps) {
+    if (items.length === 0) return null;
+
+    return (
+        <div className="flex flex-wrap gap-1.5 mb-2">
+            {items.map((item) => (
+                <span
+                    key={`${item.type}-${item.id}`}
+                    className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium border ${
+                        SCOPE_COLORS[item.type] || "bg-gray-100 text-gray-800 border-gray-200"
+                    }`}
+                >
+                    {SCOPE_ICONS[item.type] || null}
+                    <span className="max-w-[150px] truncate">{item.label}</span>
+                    <button
+                        type="button"
+                        onClick={() => onRemove(item.id)}
+                        className="ml-0.5 hover:bg-black/10 dark:hover:bg-white/10 rounded-full p-0.5"
+                        aria-label={`Remove ${item.label} from scope`}
+                    >
+                        <X className="h-3 w-3" />
+                    </button>
+                </span>
+            ))}
+        </div>
+    );
+}

--- a/client/src/lib/schema.ts
+++ b/client/src/lib/schema.ts
@@ -541,3 +541,19 @@ export interface UseSubscriptionReturn {
     error: string | null;
     refetch: () => Promise<void>;
 }
+
+export type ScopeType = "paper" | "project" | "highlight" | "comment";
+
+export interface ScopeItem {
+    type: ScopeType;
+    id: string;
+    label: string;
+    subtitle?: string;
+}
+
+export interface MentionResult {
+    papers: ScopeItem[];
+    projects: ScopeItem[];
+    highlights: ScopeItem[];
+    comments: ScopeItem[];
+}

--- a/server/app/api/message_api.py
+++ b/server/app/api/message_api.py
@@ -117,6 +117,7 @@ class MultiPaperChatRequest(BaseModel):
     user_references: Optional[List[str]] = None
     llm_provider: Optional[LLMProvider] = None
     project_id: Optional[str] = None
+    scope: Optional[List[dict]] = None
 
 
 @message_router.post("/chat/everything")
@@ -189,6 +190,7 @@ async def chat_message_multipaper(
                     user_references=request.user_references,
                     db=db,
                     project_id=request.project_id,
+                    scope=request.scope,
                 ):
                     # Parse the chunk as a dictionary
                     if isinstance(chunk, dict):
@@ -243,6 +245,7 @@ async def chat_message_multipaper(
                     current_user=current_user,
                     all_papers=all_papers,
                     db=db,
+                    scope=request.scope,
                 )
                 async for stream_chunk in _stream_chat_chunks(
                     chunk_generator=chat_generator,

--- a/server/app/api/search_api.py
+++ b/server/app/api/search_api.py
@@ -2,12 +2,14 @@ import logging
 
 from app.auth.dependencies import get_required_user
 from app.database.database import get_db
-from app.database.models import Annotation, Highlight, Paper
+from app.database.models import Annotation, Highlight, Paper, Project, ProjectRole
 from app.database.queries.search import search_knowledge_base
 from app.database.telemetry import track_event
+from app.schemas.scope import MentionItem, MentionResult, ScopeType
 from app.schemas.user import CurrentUser
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
+from sqlalchemy import or_, func
 from sqlalchemy.orm import Session
 
 logger = logging.getLogger(__name__)
@@ -125,4 +127,100 @@ async def get_search_stats(
         logger.error(f"Error getting search stats: {e}", exc_info=True)
         raise HTTPException(
             status_code=500, detail="An error occurred while getting search statistics"
+        )
+
+
+@search_router.get("/mentions")
+async def search_mentions(
+    q: str = Query(..., description="Search query for @-mention autocomplete"),
+    limit: int = Query(
+        5, ge=1, le=20, description="Max results per section"
+    ),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(get_required_user),
+):
+    """
+    Search for papers, projects, highlights, and comments to power the
+    @-mention autocomplete in the Ask input.
+    Results are grouped by type for rendering in the dropdown.
+    """
+    try:
+        if not q or len(q.strip()) < 1:
+            return JSONResponse(
+                status_code=200,
+                content=MentionResult().model_dump(),
+            )
+
+        search_pattern = f"%{q.lower()}%"
+
+        # Search papers by title
+        paper_query = (
+            db.query(Paper)
+            .filter(
+                Paper.user_id == current_user.id,
+                func.lower(Paper.title).like(search_pattern),
+            )
+            .order_by(Paper.last_accessed_at.desc())
+            .limit(limit)
+            .all()
+        )
+
+        papers = [
+            MentionItem(
+                type=ScopeType.PAPER,
+                id=str(p.id),
+                label=p.title or "Untitled Paper",
+                subtitle=", ".join(p.authors[:2]) + (" et al." if len(p.authors) > 2 else "") if p.authors else None,
+            )
+            for p in paper_query
+            if p.title
+        ]
+
+        # Search projects by title
+        # Direct query on Project model since projects are visible via ProjectRole
+        project_query = (
+            db.query(Project)
+            .filter(
+                func.lower(Project.title).like(search_pattern),
+                Project.id.in_(
+                    db.query(ProjectRole.project_id).filter(
+                        ProjectRole.user_id == current_user.id,
+                    )
+                ),
+            )
+            .order_by(Project.title)
+            .limit(limit)
+            .all()
+        )
+
+        projects = [
+            MentionItem(
+                type=ScopeType.PROJECT,
+                id=str(p.id),
+                label=p.title or "Untitled Project",
+                subtitle=p.description,
+            )
+            for p in project_query
+            if p.title
+        ]
+
+        # Deferred: highlights and comments support
+        # TODO: Add highlight search by raw_text
+        # TODO: Add comment (annotation) search by content
+
+        result = MentionResult(
+            papers=papers,
+            projects=projects,
+        )
+
+        return JSONResponse(
+            status_code=200,
+            content=result.model_dump(),
+        )
+
+    except Exception as e:
+        logger.error(f"Error searching mentions: {e}", exc_info=True)
+        raise HTTPException(
+            status_code=500,
+            detail="An error occurred while searching for mentions",
         )

--- a/server/app/llm/evidence_operations.py
+++ b/server/app/llm/evidence_operations.py
@@ -45,6 +45,7 @@ from app.schemas.message import (
     OriginalSnippet,
     ToolResultCompactionResponse,
 )
+from app.schemas.scope import filter_papers_by_scope
 from app.schemas.user import CurrentUser
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -112,6 +113,7 @@ class EvidenceOperations(BaseLLMClient):
         llm_provider: Optional[LLMProvider] = None,
         user_references: Optional[Sequence[str]] = None,
         project_id: Optional[str] = None,
+        scope: Optional[List[dict]] = None,
         db: Session = Depends(get_db),
     ) -> AsyncGenerator[
         Mapping[str, Union[str, Dict[str, List[str]], EvidenceCollection]], None
@@ -157,6 +159,28 @@ class EvidenceOperations(BaseLLMClient):
                 db,
                 user=current_user,
             )
+
+        # Apply scope filtering if specified
+        if scope:
+            all_papers = filter_papers_by_scope(
+                all_papers,
+                scope,
+                get_project_papers_fn=lambda project_id: (
+                    project_paper_crud.get_all_papers_by_project_id(
+                        db, project_id=uuid.UUID(project_id), user=current_user
+                    )
+                ),
+            )
+            if not all_papers:
+                yield {
+                    "type": "status",
+                    "content": "No papers found matching the selected scope.",
+                }
+                yield {
+                    "type": "evidence_gathered",
+                    "content": EvidenceCollection(),
+                }
+                return
 
         formatted_paper_options = {
             str(paper.id): {

--- a/server/app/llm/multi_paper_operations.py
+++ b/server/app/llm/multi_paper_operations.py
@@ -24,6 +24,7 @@ from app.llm.provider import LLMProvider, StreamChunk, SupplementaryContent, Tex
 from app.llm.utils import retry_llm_operation
 from app.schemas.message import EvidenceCollection
 from app.schemas.responses import AudioOverviewForLLM
+from app.schemas.scope import ScopeItem, ScopeType
 from app.schemas.user import CurrentUser
 from fastapi import Depends
 from sqlalchemy.orm import Session
@@ -46,6 +47,7 @@ class MultiPaperOperations(EvidenceOperations):
         evidence_gathered: EvidenceCollection,
         llm_provider: Optional[LLMProvider] = None,
         user_references: Optional[Sequence[str]] = None,
+        scope: Optional[List[dict]] = None,
         db: Session = Depends(get_db),
     ) -> AsyncGenerator[Union[str, dict], None]:
         """
@@ -56,6 +58,27 @@ class MultiPaperOperations(EvidenceOperations):
             if user_references
             else None
         )
+
+        # Build scope instruction for the LLM
+        scope_instruction = ""
+        if scope:
+            labels = []
+            for item in scope:
+                try:
+                    parsed = ScopeItem.model_validate(item)
+                    labels.append(f'"{parsed.label}" ({parsed.type.value})')
+                except Exception:
+                    continue
+            if labels:
+                scope_instruction = (
+                    "IMPORTANT: The user has scoped this query to specific items. "
+                    "Your answer MUST ONLY reference evidence from the following items "
+                    "in the library:\n"
+                    + "\n".join(f"- {label}" for label in labels)
+                    + "\n\nDo NOT reference any other papers, projects, or sources "
+                    "outside this scope. If the answer cannot be found within these "
+                    "scoped items, say so rather than using information from other sources."
+                )
 
         casted_conversation_id = uuid.UUID(conversation_id)
 
@@ -71,6 +94,7 @@ class MultiPaperOperations(EvidenceOperations):
 
         formatted_system_prompt = ANSWER_EVIDENCE_BASED_QUESTION_SYSTEM_PROMPT.format(
             available_papers=formatted_paper_options,
+            scope_instruction=scope_instruction,
         )
 
         formatted_prompt = ANSWER_EVIDENCE_BASED_QUESTION_MESSAGE.format(

--- a/server/app/llm/prompts.py
+++ b/server/app/llm/prompts.py
@@ -266,6 +266,8 @@ These are the papers available in the library:
 
 You will receive collected evidence from a research assistant in a <collected_evidence> block within the user's message. This evidence has been gathered from the papers above. Use it to inform your answer to the user's question.
 
+{scope_instruction}
+
 If a <resolved_citations> block is present, the requested citation(s) are already being delivered to the user separately. Do NOT write out a formatted citation string, and do NOT mention how or where the citation appears (no references to cards, panels, or the UI). If the user only asked for a citation, reply with a brief, natural sentence and flag any metadata that could not be found; otherwise just answer their question normally.
 
 Bear in mind that the evidence may be snippets from the papers, not the full text. You must provide a comprehensive answer that synthesizes the information from the evidence, while also adhering to the following strict formatting rules:

--- a/server/app/schemas/scope.py
+++ b/server/app/schemas/scope.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import enum
+from typing import Callable, List, Optional
+
+from pydantic import BaseModel
+
+
+class ScopeType(str, enum.Enum):
+    PAPER = "paper"
+    PROJECT = "project"
+    HIGHLIGHT = "highlight"
+    COMMENT = "comment"
+
+
+class ScopeItem(BaseModel):
+    type: ScopeType
+    id: str
+    label: str
+
+    def model_dump(self, **kwargs):
+        d = super().model_dump(**kwargs)
+        d["type"] = self.type.value
+        return d
+
+
+class MentionItem(BaseModel):
+    type: ScopeType
+    id: str
+    label: str
+    subtitle: Optional[str] = None
+
+
+class MentionResult(BaseModel):
+    papers: List[MentionItem] = []
+    projects: List[MentionItem] = []
+    highlights: List[MentionItem] = []
+    comments: List[MentionItem] = []
+
+
+def filter_papers_by_scope(
+    all_papers: list,
+    scope: Optional[List[dict]],
+    get_project_papers_fn: Optional[Callable] = None,
+) -> list:
+    """Filter papers based on scope constraints.
+
+    Supports paper IDs and project IDs. When projects are scoped, all
+    papers belonging to those projects are included. Returns the full
+    paper list when scope is empty/None (backward compatible).
+
+    Args:
+        all_papers: Full list of paper ORM objects.
+        scope: List of scope item dicts with type/id/label.
+        get_project_papers_fn: Optional callable that takes a project ID
+            (as a string) and returns a list of papers. Required when
+            scope includes projects.
+
+    Returns:
+        Filtered list of papers.
+    """
+    if not scope:
+        return all_papers
+
+    allowed_paper_ids: set = set()
+    paper_ids_from_projects: set = set()
+
+    for item in scope:
+        try:
+            parsed = ScopeItem.model_validate(item)
+        except Exception:
+            continue
+
+        if parsed.type == ScopeType.PAPER:
+            allowed_paper_ids.add(parsed.id)
+        elif parsed.type == ScopeType.PROJECT and get_project_papers_fn:
+            project_papers = get_project_papers_fn(parsed.id)
+            for p in project_papers:
+                paper_ids_from_projects.add(str(p.id))
+
+    allowed_paper_ids |= paper_ids_from_projects
+
+    if not allowed_paper_ids:
+        return []
+
+    return [p for p in all_papers if str(p.id) in allowed_paper_ids]

--- a/server/tests/test_scope.py
+++ b/server/tests/test_scope.py
@@ -1,0 +1,197 @@
+import unittest
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from app.schemas.scope import MentionItem, MentionResult, ScopeItem, ScopeType
+
+
+class TestScopeItem(unittest.TestCase):
+    def test_scope_item_creation_paper(self) -> None:
+        item = ScopeItem(type=ScopeType.PAPER, id="paper-123", label="Transformers")
+        self.assertEqual(item.type, ScopeType.PAPER)
+        self.assertEqual(item.id, "paper-123")
+        self.assertEqual(item.label, "Transformers")
+
+    def test_scope_item_creation_project(self) -> None:
+        item = ScopeItem(type=ScopeType.PROJECT, id="proj-456", label="NLP Papers")
+        self.assertEqual(item.type, ScopeType.PROJECT)
+        self.assertEqual(item.id, "proj-456")
+        self.assertEqual(item.label, "NLP Papers")
+
+    def test_scope_item_model_dump_returns_type_value(self) -> None:
+        item = ScopeItem(type=ScopeType.PAPER, id="p1", label="Paper 1")
+        dumped = item.model_dump()
+        self.assertEqual(dumped["type"], "paper")
+        self.assertEqual(dumped["id"], "p1")
+        self.assertEqual(dumped["label"], "Paper 1")
+
+
+class TestScopeType(unittest.TestCase):
+    def test_all_enum_values_present(self) -> None:
+        values = {e.value for e in ScopeType}
+        self.assertIn("paper", values)
+        self.assertIn("project", values)
+        self.assertIn("highlight", values)
+        self.assertIn("comment", values)
+
+    def test_scope_type_from_string(self) -> None:
+        self.assertEqual(ScopeType("paper"), ScopeType.PAPER)
+        self.assertEqual(ScopeType("project"), ScopeType.PROJECT)
+        self.assertEqual(ScopeType("highlight"), ScopeType.HIGHLIGHT)
+        self.assertEqual(ScopeType("comment"), ScopeType.COMMENT)
+
+    def test_invalid_scope_type_raises(self) -> None:
+        with self.assertRaises(ValueError):
+            ScopeType("invalid_type")
+
+
+class TestMentionItem(unittest.TestCase):
+    def test_mention_item_with_subtitle(self) -> None:
+        item = MentionItem(
+            type=ScopeType.PAPER,
+            id="p1",
+            label="Attention Is All You Need",
+            subtitle="Vaswani et al.",
+        )
+        self.assertEqual(item.subtitle, "Vaswani et al.")
+
+    def test_mention_item_without_subtitle(self) -> None:
+        item = MentionItem(
+            type=ScopeType.PROJECT,
+            id="proj-1",
+            label="My Project",
+        )
+        self.assertIsNone(item.subtitle)
+
+
+class TestMentionResult(unittest.TestCase):
+    def test_empty_result(self) -> None:
+        result = MentionResult()
+        self.assertEqual(result.papers, [])
+        self.assertEqual(result.projects, [])
+        self.assertEqual(result.highlights, [])
+        self.assertEqual(result.comments, [])
+
+    def test_result_with_papers_and_projects(self) -> None:
+        paper = MentionItem(type=ScopeType.PAPER, id="p1", label="Paper 1")
+        project = MentionItem(type=ScopeType.PROJECT, id="proj-1", label="Project 1")
+        result = MentionResult(papers=[paper], projects=[project])
+        self.assertEqual(len(result.papers), 1)
+        self.assertEqual(len(result.projects), 1)
+        self.assertEqual(result.papers[0].label, "Paper 1")
+        self.assertEqual(result.projects[0].label, "Project 1")
+
+    def test_result_model_dump(self) -> None:
+        paper = MentionItem(type=ScopeType.PAPER, id="p1", label="Paper 1")
+        result = MentionResult(papers=[paper])
+        dumped = result.model_dump()
+        self.assertEqual(dumped["papers"][0]["type"], "paper")
+        self.assertEqual(dumped["projects"], [])
+        self.assertEqual(dumped["highlights"], [])
+        self.assertEqual(dumped["comments"], [])
+
+
+class TestScopeFiltering(unittest.TestCase):
+    def setUp(self) -> None:
+        self.paper_a_id = str(uuid4())
+        self.paper_b_id = str(uuid4())
+        self.paper_c_id = str(uuid4())
+        self.project_id = str(uuid4())
+
+        self.mock_paper_a = MagicMock()
+        self.mock_paper_a.id = self.paper_a_id
+        self.mock_paper_b = MagicMock()
+        self.mock_paper_b.id = self.paper_b_id
+        self.mock_paper_c = MagicMock()
+        self.mock_paper_c.id = self.paper_c_id
+
+        self.all_papers = [self.mock_paper_a, self.mock_paper_b, self.mock_paper_c]
+
+    def test_filter_by_paper_ids(self) -> None:
+        """Filtering by paper IDs returns only matching papers."""
+        scope = [
+            {"type": "paper", "id": self.paper_a_id, "label": "Paper A"},
+            {"type": "paper", "id": self.paper_c_id, "label": "Paper C"},
+        ]
+        from app.schemas.scope import filter_papers_by_scope
+
+        filtered = filter_papers_by_scope(self.all_papers, scope)
+        self.assertEqual(len(filtered), 2)
+        self.assertIn(self.mock_paper_a, filtered)
+        self.assertIn(self.mock_paper_c, filtered)
+        self.assertNotIn(self.mock_paper_b, filtered)
+
+    def test_filter_no_scope_returns_all(self) -> None:
+        """When scope is None or empty, all papers are returned."""
+        from app.schemas.scope import filter_papers_by_scope
+
+        filtered = filter_papers_by_scope(self.all_papers, None)
+        self.assertEqual(len(filtered), 3)
+
+        filtered = filter_papers_by_scope(self.all_papers, [])
+        self.assertEqual(len(filtered), 3)
+
+    def test_filter_by_project(self) -> None:
+        """Filtering by project returns papers belonging to that project."""
+        def get_project_papers(project_id: str) -> list:
+            return [self.mock_paper_a, self.mock_paper_b]
+
+        scope = [
+            {"type": "project", "id": self.project_id, "label": "My Project"},
+        ]
+        from app.schemas.scope import filter_papers_by_scope
+
+        filtered = filter_papers_by_scope(
+            self.all_papers, scope, get_project_papers_fn=get_project_papers
+        )
+        self.assertEqual(len(filtered), 2)
+        self.assertIn(self.mock_paper_a, filtered)
+        self.assertIn(self.mock_paper_b, filtered)
+        self.assertNotIn(self.mock_paper_c, filtered)
+
+    def test_filter_by_paper_and_project_union(self) -> None:
+        """Filtering by both paper and project takes the union."""
+        def get_project_papers(project_id: str) -> list:
+            return [self.mock_paper_b]
+
+        scope = [
+            {"type": "paper", "id": self.paper_a_id, "label": "Paper A"},
+            {"type": "project", "id": self.project_id, "label": "My Project"},
+        ]
+        from app.schemas.scope import filter_papers_by_scope
+
+        filtered = filter_papers_by_scope(
+            self.all_papers, scope, get_project_papers_fn=get_project_papers
+        )
+        self.assertEqual(len(filtered), 2)
+        self.assertIn(self.mock_paper_a, filtered)
+        self.assertIn(self.mock_paper_b, filtered)
+        self.assertNotIn(self.mock_paper_c, filtered)
+
+    def test_empty_scope_returns_empty_list(self) -> None:
+        """When scope contains only non-existent IDs, return empty list."""
+        scope = [
+            {"type": "paper", "id": str(uuid4()), "label": "Non-existent"},
+        ]
+        from app.schemas.scope import filter_papers_by_scope
+
+        filtered = filter_papers_by_scope(self.all_papers, scope)
+        self.assertEqual(len(filtered), 0)
+
+    def test_invalid_scope_item_skipped(self) -> None:
+        """Invalid scope items (missing fields) are skipped gracefully."""
+        scope = [
+            {"type": "paper", "id": self.paper_a_id, "label": "Paper A"},
+            {"type": "invalid_type", "id": "x", "label": "Invalid"},
+            {"id": "y"},  # missing type
+        ]
+        from app.schemas.scope import filter_papers_by_scope
+
+        filtered = filter_papers_by_scope(self.all_papers, scope)
+        # Only the valid paper scope should apply
+        self.assertEqual(len(filtered), 1)
+        self.assertIn(self.mock_paper_a, filtered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I implemented end‑to‑end scoped @‑mentions for the Ask experience, from schema and retrieval to UI and LLM prompting, addressing the feature request in **#59**.

On the server side, I introduced a dedicated scope model in `server/app/schemas/scope.py` with a `ScopeType` enum (papers, projects, highlights, comments), a `ScopeItem` and `MentionItem` representation, and a `MentionResult` container. I added `filter_papers_by_scope()` to resolve project‑level scopes into the corresponding paper set and to enforce that only in‑scope papers are considered downstream.

To power the autocomplete, I added a `GET /search/mentions` endpoint in `server/app/api/search_api.py` that:

- searches papers by title for the current user,
- looks up projects via `ProjectRole` membership,
- returns results grouped by type in a `MentionResult` payload,

with highlights/comments wired at the schema level and left for a follow‑up pass.

The Ask pipeline now treats scope as a first‑class concern. `MultiPaperChatRequest` in `server/app/api/message_api.py` gained an optional `scope` field, which is threaded into `gather_evidence()` in `server/app/llm/evidence_operations.py`. Before any LLM call, `filter_papers_by_scope()` is applied so that out‑of‑scope papers never enter the evidence set; if the scope resolves to an empty set, the user gets an explicit “no papers found in scope” status and an empty evidence collection. In `server/app/llm/multi_paper_operations.py`, I build a `scope_instruction` string from the validated `ScopeItem`s and inject it into `ANSWER_EVIDENCE_BASED_QUESTION_SYSTEM_PROMPT` via `server/app/llm/prompts.py`, so the model is explicitly told to only use the scoped items and to decline to answer if the answer is not contained within them.

On the client side, I extended the shared schema in `client/src/lib/schema.ts` with a `ScopeType`, `ScopeItem`, and `MentionResult` that mirror the backend types. The new `AtMentionDropdown` component handles:

- grouped rendering for papers/projects/highlights/comments with type‑specific icons,
- debounced `fetchFromApi` calls to `/api/search/mentions` with abort handling,
- full keyboard navigation (ArrowUp/ArrowDown/Enter/Escape) and proper ARIA roles,
- stable positioning under the textarea using the input’s bounding rect.

`ScopeChips` renders the active scope as removable chips with type‑aware styling and icons.

I integrated both into `ConversationView` by:

- tracking @‑mention state (open/closed, search term, anchor rect) and scope state,
- detecting `@` in the textarea, extracting the active search token, and opening the dropdown,
- using a callback ref to share the same textarea instance between the existing chat flow and the new dropdown positioning logic,
- stripping the inline `@…` token from the user message upon selection and appending the chosen item to the scope.

The scope is then lifted into `UnderstandPageContent` in `client/src/app/(main)/(protected)/understand/page.tsx` and included on every Ask request as an optional `scope` field when non‑empty, so unscoped queries retain