### PR TITLE
Add projects filter to the library table

### DIFF
--- a/client/src/components/LibraryTable.tsx
+++ b/client/src/components/LibraryTable.tsx
@@ -20,10 +20,11 @@ import {
 	SheetContent,
 } from "@/components/ui/sheet";
 import { useIsMobile } from "@/hooks/use-mobile";
-import { ArrowUpDown, CheckCheck, Trash2, X, ChevronDown, Tag } from "lucide-react";
+import { ArrowUpDown, ArrowUpRight, CheckCheck, Trash2, X, ChevronDown, Tag } from "lucide-react";
+import Link from "next/link";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { PaperPreview } from "./PaperPreview";
-import { PaperFiltering, Filter, Sort, NO_TAGS_FILTER_VALUE, NO_PROJECT_FILTER_VALUE, projectLabel } from "@/components/PaperFiltering";
+import { PaperFiltering, Filter, Sort, NO_TAGS_FILTER_VALUE, NO_PROJECT_FILTER_VALUE } from "@/components/PaperFiltering";
 import { Badge } from "@/components/ui/badge";
 import { TagSelector } from "./TagSelector";
 import { toast } from "sonner";
@@ -93,7 +94,7 @@ export function LibraryTable({
 					paper.authors?.join(', ').toLowerCase().includes(term) ||
 					paper.institutions?.join(', ').toLowerCase().includes(term) ||
 					paper.tags?.map(t => t.name).join(', ').toLowerCase().includes(term) ||
-					paper.projects?.map(p => projectLabel(p)).join(', ').toLowerCase().includes(term)
+					paper.projects?.map(p => p.title).join(', ').toLowerCase().includes(term)
 				);
 			});
 		}
@@ -273,7 +274,7 @@ export function LibraryTable({
 		const titles = new Map<string, string>();
 		for (const paper of papers || []) {
 			for (const project of paper.projects || []) {
-				titles.set(project.id, projectLabel(project));
+				titles.set(project.id, project.title);
 			}
 		}
 		return titles;
@@ -628,20 +629,7 @@ export function LibraryTable({
 																</button>
 															)}
 														</div>
-													) : (
-														<span
-														className="text-muted-foreground cursor-pointer hover:underline"
-														onClick={(e) => {
-															e.stopPropagation();
-															const noTagsFilter: Filter = { type: 'tag', value: NO_TAGS_FILTER_VALUE };
-															if (!filters.some(f => f.type === 'tag' && f.value === NO_TAGS_FILTER_VALUE)) {
-																setFilters([...filters, noTagsFilter]);
-															}
-														}}
-													>
-														No tags
-													</span>
-													)}
+													) : null}
 												</div>
 											</TableCell>
 											<TableCell className="py-4 pr-4">
@@ -652,9 +640,17 @@ export function LibraryTable({
 																<span
 																	key={project.id}
 																	onClick={(e) => { e.stopPropagation(); addFilter({ type: 'project', value: project.id }); }}
-																	className="inline-flex items-center px-2 py-1 bg-secondary text-secondary-foreground rounded-sm cursor-pointer hover:bg-secondary/80 transition-colors"
+																	className="group relative inline-flex items-center px-2 py-1 bg-secondary text-secondary-foreground rounded-sm cursor-pointer hover:bg-secondary/80 transition-colors"
 																>
-																	{projectLabel(project)}
+																	{project.title}
+																	<Link
+																		href={`/projects/${project.id}`}
+																		onClick={(e) => e.stopPropagation()}
+																		aria-label={`Open project ${project.title}`}
+																		className="ml-1.5 -mr-1 p-0.5 bg-foreground/10 text-muted-foreground rounded-full opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity"
+																	>
+																		<ArrowUpRight className="h-2.5 w-2.5" />
+																	</Link>
 																</span>
 															))}
 															{paper.projects.length > 2 && !expandedProjects.has(paper.id) && (
@@ -666,17 +662,7 @@ export function LibraryTable({
 																</button>
 															)}
 														</div>
-													) : (
-														<span
-															className="text-muted-foreground cursor-pointer hover:underline"
-															onClick={(e) => {
-																e.stopPropagation();
-																addFilter({ type: 'project', value: NO_PROJECT_FILTER_VALUE });
-															}}
-														>
-															No project
-														</span>
-													)}
+													) : null}
 												</div>
 											</TableCell>
 											<TableCell className="py-4 pr-4">

--- a/client/src/components/LibraryTable.tsx
+++ b/client/src/components/LibraryTable.tsx
@@ -23,7 +23,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import { ArrowUpDown, CheckCheck, Trash2, X, ChevronDown, Tag } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { PaperPreview } from "./PaperPreview";
-import { PaperFiltering, Filter, Sort, NO_TAGS_FILTER_VALUE } from "@/components/PaperFiltering";
+import { PaperFiltering, Filter, Sort, NO_TAGS_FILTER_VALUE, NO_PROJECT_FILTER_VALUE, projectLabel } from "@/components/PaperFiltering";
 import { Badge } from "@/components/ui/badge";
 import { TagSelector } from "./TagSelector";
 import { toast } from "sonner";
@@ -61,6 +61,7 @@ export function LibraryTable({
 	const [selectedPaperForPreview, setSelectedPaperForPreview] = useState<PaperItem | null>(null);
 	const [taggingPopoverOpen, setTaggingPopoverOpen] = useState(false);
 	const [expandedTags, setExpandedTags] = useState<Set<string>>(new Set());
+	const [expandedProjects, setExpandedProjects] = useState<Set<string>>(new Set());
 	const tableContainerRef = useRef<HTMLDivElement>(null);
 
 	const maxHeight = 'calc(100vh - 16rem)';
@@ -91,7 +92,8 @@ export function LibraryTable({
 					paper.title?.toLowerCase().includes(term) ||
 					paper.authors?.join(', ').toLowerCase().includes(term) ||
 					paper.institutions?.join(', ').toLowerCase().includes(term) ||
-					paper.tags?.map(t => t.name).join(', ').toLowerCase().includes(term)
+					paper.tags?.map(t => t.name).join(', ').toLowerCase().includes(term) ||
+					paper.projects?.map(p => projectLabel(p)).join(', ').toLowerCase().includes(term)
 				);
 			});
 		}
@@ -107,6 +109,12 @@ export function LibraryTable({
 							return !paper.tags?.length;
 						}
 						return paper.tags?.some(t => t.name === filter.value);
+					}
+					if (filter.type === 'project') {
+						if (filter.value === NO_PROJECT_FILTER_VALUE) {
+							return !paper.projects?.length;
+						}
+						return paper.projects?.some(p => p.id === filter.value);
 					}
 					if (filter.type === 'status') {
 						return paper.status === filter.value;
@@ -235,11 +243,47 @@ export function LibraryTable({
 		});
 	};
 
+	const toggleExpandedProjects = (paperId: string) => {
+		setExpandedProjects(prev => {
+			const newSet = new Set(prev);
+			if (newSet.has(paperId)) {
+				newSet.delete(paperId);
+			} else {
+				newSet.add(paperId);
+			}
+			return newSet;
+		});
+	};
+
 	const handleTagClick = (tagName: string) => {
 		const newFilter: Filter = { type: 'tag', value: tagName };
 		if (!filters.some(f => f.type === 'tag' && f.value === tagName)) {
 			setFilters([...filters, newFilter]);
 		}
+	};
+
+	const addFilter = (filter: Filter) => {
+		if (!filters.some(f => f.type === filter.type && f.value === filter.value)) {
+			setFilters([...filters, filter]);
+		}
+	};
+
+	// Project filters store the project id, so resolve a display title for the chips.
+	const projectTitlesById = useMemo(() => {
+		const titles = new Map<string, string>();
+		for (const paper of papers || []) {
+			for (const project of paper.projects || []) {
+				titles.set(project.id, projectLabel(project));
+			}
+		}
+		return titles;
+	}, [papers]);
+
+	const filterLabel = (filter: Filter) => {
+		if (filter.value === NO_TAGS_FILTER_VALUE) return 'No tags';
+		if (filter.value === NO_PROJECT_FILTER_VALUE) return 'No project';
+		if (filter.type === 'project') return projectTitlesById.get(filter.value) ?? 'Unknown project';
+		return filter.value;
 	};
 
 	const handleRemoveTag = async (paperId: string, tagId: string) => {
@@ -274,7 +318,7 @@ export function LibraryTable({
 		);
 	}
 
-	const numCols = 6 + (selectable ? 1 : 0);
+	const numCols = 7 + (selectable ? 1 : 0);
 	const allAvailableSelected = availablePapers.length > 0 && selectedPapers.size === availablePapers.length;
 
 
@@ -393,12 +437,12 @@ export function LibraryTable({
 			<div className="flex flex-wrap gap-2 mb-4">
 				{filters.map(filter => (
 					<Badge key={`${filter.type}-${filter.value}`} variant="secondary" className="flex items-center gap-1">
-						{filter.type}: {filter.value === NO_TAGS_FILTER_VALUE ? 'No tags' : filter.value}
+						{filter.type}: {filterLabel(filter)}
 						<Button
 							variant="ghost"
 							size="sm"
 							className="h-4 w-4 p-0"
-							onClick={() => setFilters(filters.filter(f => f.value !== filter.value))}
+							onClick={() => setFilters(filters.filter(f => !(f.type === filter.type && f.value === filter.value)))}
 						>
 							<X className="h-3 w-3" />
 						</Button>
@@ -463,6 +507,14 @@ export function LibraryTable({
 											className="h-auto p-0 font-semibold hover:bg-transparent hover:text-primary"
 										>
 											Tags
+										</Button>
+									</TableHead>
+									<TableHead className="min-w-[10rem]">
+										<Button
+											variant="ghost"
+											className="h-auto p-0 font-semibold hover:bg-transparent hover:text-primary"
+										>
+											Projects
 										</Button>
 									</TableHead>
 									<TableHead className="min-w-[8rem]">
@@ -589,6 +641,41 @@ export function LibraryTable({
 													>
 														No tags
 													</span>
+													)}
+												</div>
+											</TableCell>
+											<TableCell className="py-4 pr-4">
+												<div className="text-xs leading-relaxed">
+													{paper.projects?.length ? (
+														<div className="flex flex-wrap gap-1 items-center">
+															{(expandedProjects.has(paper.id) ? paper.projects : paper.projects.slice(0, 2)).map((project) => (
+																<span
+																	key={project.id}
+																	onClick={(e) => { e.stopPropagation(); addFilter({ type: 'project', value: project.id }); }}
+																	className="inline-flex items-center px-2 py-1 bg-secondary text-secondary-foreground rounded-sm cursor-pointer hover:bg-secondary/80 transition-colors"
+																>
+																	{projectLabel(project)}
+																</span>
+															))}
+															{paper.projects.length > 2 && !expandedProjects.has(paper.id) && (
+																<button
+																	onClick={(e) => { e.stopPropagation(); toggleExpandedProjects(paper.id); }}
+																	className="text-muted-foreground text-xs hover:underline"
+																>
+																	+ {paper.projects.length - 2} more
+																</button>
+															)}
+														</div>
+													) : (
+														<span
+															className="text-muted-foreground cursor-pointer hover:underline"
+															onClick={(e) => {
+																e.stopPropagation();
+																addFilter({ type: 'project', value: NO_PROJECT_FILTER_VALUE });
+															}}
+														>
+															No project
+														</span>
 													)}
 												</div>
 											</TableCell>

--- a/client/src/components/PaperFiltering.tsx
+++ b/client/src/components/PaperFiltering.tsx
@@ -22,15 +22,20 @@ import {
 } from "@/components/ui/command"
 import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Check } from "lucide-react"
-import { PaperItem } from "@/lib/schema";
+import { PaperItem, PaperProject } from "@/lib/schema";
 import { PaperStatusEnum } from "@/components/utils/PdfStatus";
 
 export type Filter = {
-    type: "author" | "status" | "tag"
+    type: "author" | "status" | "tag" | "project"
     value: string
 }
 
 export const NO_TAGS_FILTER_VALUE = "__NO_TAGS__";
+export const NO_PROJECT_FILTER_VALUE = "__NO_PROJECT__";
+
+// Project filters carry the project id, not its title: titles are nullable and
+// may collide with each other or with a tag of the same name.
+export const projectLabel = (project: PaperProject) => project.title || "Untitled project";
 
 export type Sort = {
     type: "publish_date"
@@ -49,6 +54,9 @@ interface PaperFilteringProps {
 export function PaperFiltering({ papers, onFilterChange, onSortChange, filters, sort, showSort = true }: PaperFilteringProps) {
     const authors = Array.from(new Set(papers.flatMap(p => p.authors || [])))
     const tags = Array.from(new Set(papers.flatMap(p => p.tags?.map(t => t.name) || [])))
+    const projects = Array.from(
+        new Map(papers.flatMap(p => p.projects || []).map(project => [project.id, project])).values()
+    ).sort((a, b) => projectLabel(a).localeCompare(projectLabel(b)))
 
     const handleSelectFilter = (filter: Filter) => {
         const newFilters = filters.some(f => f.type === filter.type && f.value === filter.value)
@@ -101,6 +109,41 @@ export function PaperFiltering({ papers, onFilterChange, onSortChange, filters, 
                     }
                     <DropdownMenuLabel>Filter by</DropdownMenuLabel>
                     <DropdownMenuGroup>
+                        <DropdownMenuSub>
+                            <DropdownMenuSubTrigger>Projects</DropdownMenuSubTrigger>
+                            <DropdownMenuSubContent className="p-0">
+                                <Command>
+                                    <CommandInput
+                                        placeholder="Filter project..."
+                                        autoFocus={true}
+                                        className="h-9"
+                                    />
+                                    <CommandList>
+                                        <CommandEmpty>No projects found.</CommandEmpty>
+                                        <CommandGroup>
+                                            <CommandItem
+                                                value="No project"
+                                                onSelect={() => handleSelectFilter({ type: "project", value: NO_PROJECT_FILTER_VALUE })}
+                                                className="text-muted-foreground"
+                                            >
+                                                {isFilterActive({ type: "project", value: NO_PROJECT_FILTER_VALUE }) && <Check className="mr-2 h-4 w-4" />}
+                                                No project
+                                            </CommandItem>
+                                            {projects.map(project => (
+                                                <CommandItem
+                                                    key={project.id}
+                                                    value={`${projectLabel(project)}-${project.id}`}
+                                                    onSelect={() => handleSelectFilter({ type: "project", value: project.id })}
+                                                >
+                                                    {isFilterActive({ type: "project", value: project.id }) && <Check className="mr-2 h-4 w-4" />}
+                                                    {projectLabel(project)}
+                                                </CommandItem>
+                                            ))}
+                                        </CommandGroup>
+                                    </CommandList>
+                                </Command>
+                            </DropdownMenuSubContent>
+                        </DropdownMenuSub>
                         <DropdownMenuSub>
                             <DropdownMenuSubTrigger>Authors</DropdownMenuSubTrigger>
                             <DropdownMenuSubContent className="p-0">

--- a/client/src/components/PaperFiltering.tsx
+++ b/client/src/components/PaperFiltering.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/command"
 import { Button } from "@/components/ui/button"
 import { ChevronsUpDown, Check } from "lucide-react"
-import { PaperItem, PaperProject } from "@/lib/schema";
+import { PaperItem } from "@/lib/schema";
 import { PaperStatusEnum } from "@/components/utils/PdfStatus";
 
 export type Filter = {
@@ -32,10 +32,6 @@ export type Filter = {
 
 export const NO_TAGS_FILTER_VALUE = "__NO_TAGS__";
 export const NO_PROJECT_FILTER_VALUE = "__NO_PROJECT__";
-
-// Project filters carry the project id, not its title: titles are nullable and
-// may collide with each other or with a tag of the same name.
-export const projectLabel = (project: PaperProject) => project.title || "Untitled project";
 
 export type Sort = {
     type: "publish_date"
@@ -56,7 +52,7 @@ export function PaperFiltering({ papers, onFilterChange, onSortChange, filters, 
     const tags = Array.from(new Set(papers.flatMap(p => p.tags?.map(t => t.name) || [])))
     const projects = Array.from(
         new Map(papers.flatMap(p => p.projects || []).map(project => [project.id, project])).values()
-    ).sort((a, b) => projectLabel(a).localeCompare(projectLabel(b)))
+    ).sort((a, b) => a.title.localeCompare(b.title))
 
     const handleSelectFilter = (filter: Filter) => {
         const newFilters = filters.some(f => f.type === filter.type && f.value === filter.value)
@@ -132,11 +128,11 @@ export function PaperFiltering({ papers, onFilterChange, onSortChange, filters, 
                                             {projects.map(project => (
                                                 <CommandItem
                                                     key={project.id}
-                                                    value={`${projectLabel(project)}-${project.id}`}
+                                                    value={`${project.title}-${project.id}`}
                                                     onSelect={() => handleSelectFilter({ type: "project", value: project.id })}
                                                 >
                                                     {isFilterActive({ type: "project", value: project.id }) && <Check className="mr-2 h-4 w-4" />}
-                                                    {projectLabel(project)}
+                                                    {project.title}
                                                 </CommandItem>
                                             ))}
                                         </CommandGroup>

--- a/client/src/lib/schema.ts
+++ b/client/src/lib/schema.ts
@@ -363,7 +363,7 @@ export interface PaperTag {
 
 export interface PaperProject {
     id: string;
-    title: string | null;
+    title: string;
 }
 
 export interface PaperItem {

--- a/client/src/lib/schema.ts
+++ b/client/src/lib/schema.ts
@@ -361,6 +361,11 @@ export interface PaperTag {
     color: string;
 }
 
+export interface PaperProject {
+    id: string;
+    title: string | null;
+}
+
 export interface PaperItem {
     id: string
     title: string
@@ -375,6 +380,7 @@ export interface PaperItem {
     file_url?: string
     size_in_kb?: number
     tags?: PaperTag[]
+    projects?: PaperProject[]
     is_owner?: boolean
     journal?: string
     doi?: string

--- a/server/app/api/paper_api.py
+++ b/server/app/api/paper_api.py
@@ -69,7 +69,9 @@ async def get_paper_ids(
     """
     Get all paper IDs
     """
-    papers: List[Paper] = paper_crud.get_multi_uploads_completed(db, user=current_user)
+    papers: List[Paper] = paper_crud.get_multi_uploads_completed(
+        db, user=current_user, include_projects=True
+    )
 
     # Bulk retrieve presigned URLs for all papers (optimized with parallelization)
     file_urls = {}
@@ -93,6 +95,11 @@ async def get_paper_ids(
             "publish_date": (str(paper.publish_date) if paper.publish_date else None),
             "file_url": file_urls.get(str(paper.id)),
             "tags": [{"id": str(tag.id), "name": tag.name, "color": tag.color} for tag in paper.tags],  # type: ignore
+            "projects": [
+                {"id": str(pp.project.id), "title": pp.project.title}
+                for pp in paper.project_papers  # type: ignore
+                if pp.project
+            ],
         }
         for paper in papers
     ]

--- a/server/app/api/projects/projects_api.py
+++ b/server/app/api/projects/projects_api.py
@@ -153,10 +153,17 @@ async def update_project(
 ) -> JSONResponse:
     """Update an existing project"""
     try:
+        updates = request.model_dump(exclude_unset=True)
+
+        # A project must always have a title, so an explicit null means
+        # "leave it alone" rather than "clear it".
+        if "title" in updates and updates["title"] is None:
+            del updates["title"]
+
         project = project_crud.update(
             db,
             id=uuid.UUID(project_id),
-            obj_in=ProjectUpdate(**request.model_dump(exclude_unset=True)),
+            obj_in=ProjectUpdate(**updates),
             user=current_user,
         )
 

--- a/server/app/database/crud/paper_crud.py
+++ b/server/app/database/crud/paper_crud.py
@@ -18,6 +18,8 @@ from app.database.models import (
     PaperStatus,
     PaperTag,
     PaperUploadJob,
+    Project,
+    ProjectPaper,
     RoleType,
     User,
 )
@@ -285,33 +287,45 @@ class PaperCRUD(CRUDBase["Paper", PaperCreate, PaperUpdate]):
         skip: int = 0,
         limit: int = 500,
         status: Optional[PaperStatus] = None,
+        include_projects: bool = False,
     ) -> List[Paper]:
         """
         Get multiple papers that have completed uploads
         Completed uploads are those either with a null upload_job_id OR an upload_job with status 'completed'.
+
+        Pass include_projects to eagerly load each paper's project memberships.
         """
+        options = [
+            selectinload(Paper.tags),
+            # Library listings only need lightweight metadata. Without this,
+            # the query SELECT *'s heavy columns (raw_content, ts_vector,
+            # summary, summary_citations, page_offset_map) for every paper
+            # in the user's library. Both callers (/api/paper/all and
+            # /api/paper/active) serialize only the columns listed here.
+            load_only(
+                Paper.title,
+                Paper.created_at,
+                Paper.updated_at,
+                Paper.abstract,
+                Paper.authors,
+                Paper.institutions,
+                Paper.status,
+                Paper.preview_url,
+                Paper.size_in_kb,
+                Paper.publish_date,
+            ),
+        ]
+
+        if include_projects:
+            options.append(
+                selectinload(Paper.project_papers)
+                .selectinload(ProjectPaper.project)
+                .load_only(Project.title)
+            )
+
         return (
             db.query(Paper)
-            .options(
-                selectinload(Paper.tags),
-                # Library listings only need lightweight metadata. Without this,
-                # the query SELECT *'s heavy columns (raw_content, ts_vector,
-                # summary, summary_citations, page_offset_map) for every paper
-                # in the user's library. Both callers (/api/paper/all and
-                # /api/paper/active) serialize only the columns listed here.
-                load_only(
-                    Paper.title,
-                    Paper.created_at,
-                    Paper.updated_at,
-                    Paper.abstract,
-                    Paper.authors,
-                    Paper.institutions,
-                    Paper.status,
-                    Paper.preview_url,
-                    Paper.size_in_kb,
-                    Paper.publish_date,
-                ),
-            )
+            .options(*options)
             .outerjoin(PaperUploadJob, Paper.upload_job_id == PaperUploadJob.id)
             .filter(
                 Paper.user_id == user.id,

--- a/server/app/database/crud/projects/project_crud.py
+++ b/server/app/database/crud/projects/project_crud.py
@@ -31,7 +31,7 @@ class ProjectBase(BaseModel):
 
 
 class ProjectCreate(ProjectBase):
-    title: Optional[str] = None
+    title: str
     description: Optional[str] = None
 
 

--- a/server/app/database/models.py
+++ b/server/app/database/models.py
@@ -703,7 +703,7 @@ class Project(Base):
     __tablename__ = "project"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    title = Column(String, nullable=True)
+    title = Column(String, nullable=False)
     description = Column(Text, nullable=True)
     admin_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
 

--- a/server/migrations/versions/2026_07_10_1605_project_title_nonnull.py
+++ b/server/migrations/versions/2026_07_10_1605_project_title_nonnull.py
@@ -1,0 +1,32 @@
+"""project title nonnull
+
+Revision ID: c1ec0bdd6f34
+Revises: 9919a3e385a0
+Create Date: 2026-07-10 16:05:06.931204+00:00
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c1ec0bdd6f34"
+down_revision: Union[str, None] = "9919a3e385a0"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Name the untitled projects before the constraint can reject them.
+    op.execute("UPDATE project SET title = 'Untitled' WHERE title IS NULL")
+    op.alter_column("project", "title", existing_type=sa.String(), nullable=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # The backfilled 'Untitled' titles are left in place: they are
+    # indistinguishable from titles a user actually chose.
+    op.alter_column("project", "title", existing_type=sa.String(), nullable=True)


### PR DESCRIPTION
make it easier for people to filter their libraries using project-level scoping. include adding an additional backend join to fetch project membership, and filter chips / links in the library table.