### PR TITLE
Add support for using new Exa publications endpoint

### DIFF
--- a/client/src/app/(main)/(protected)/discover/DiscoverResultCard.tsx
+++ b/client/src/app/(main)/(protected)/discover/DiscoverResultCard.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { ExternalLink } from "lucide-react"
+import type { ReactNode } from "react"
 
 export interface DiscoverResult {
     title: string
@@ -15,6 +16,7 @@ export interface DiscoverResult {
     cited_by_count?: number | null
     source?: string | null
     institutions?: string[]
+    publication_type?: string | null
 }
 
 interface DiscoverResultCardProps {
@@ -54,6 +56,18 @@ function formatInstitutions(institutions?: string[]): string | null {
     return `${institutions[0]}, ${institutions[1]} +${institutions.length - 2} more`
 }
 
+// Only types that qualify how much weight to give a result are worth a badge.
+// "article" is the reader's default assumption, so labelling it adds noise.
+const PUBLICATION_TYPE_LABELS: Record<string, string> = {
+    preprint: "Preprint",
+    review: "Review",
+}
+
+function formatPublicationType(publicationType?: string | null): string | null {
+    if (!publicationType) return null
+    return PUBLICATION_TYPE_LABELS[publicationType.toLowerCase()] ?? null
+}
+
 export default function DiscoverResultCard({ result }: DiscoverResultCardProps) {
     const publishedYear = result.published_date
         ? new Date(result.published_date).getFullYear()
@@ -61,13 +75,21 @@ export default function DiscoverResultCard({ result }: DiscoverResultCardProps) 
 
     const authorsDisplay = formatAuthors(result.authors)
     const institutionsDisplay = formatInstitutions(result.institutions)
+    const publicationTypeLabel = formatPublicationType(result.publication_type)
 
     const snippet = sanitizeSnippet(
         result.summary || result.text || result.highlights?.[0] || ""
     );
 
-    // Build metadata items for the first line
-    const hasMetadata = authorsDisplay || publishedYear || result.source || (result.cited_by_count != null && result.cited_by_count > 0)
+    // Sources fill these in unevenly, so collect whatever is present and let the
+    // separators fall out of the list rather than conditioning on each pairing.
+    const metadata: { key: string; node: ReactNode }[] = []
+    if (authorsDisplay) metadata.push({ key: "authors", node: authorsDisplay })
+    if (result.source) metadata.push({ key: "source", node: <span className="italic">{result.source}</span> })
+    if (publishedYear) metadata.push({ key: "year", node: publishedYear })
+    if (result.cited_by_count != null && result.cited_by_count > 0) {
+        metadata.push({ key: "citations", node: `${result.cited_by_count.toLocaleString()} citations` })
+    }
 
     return (
         <div className="py-4 border-b border-slate-200 dark:border-slate-800 last:border-b-0 group">
@@ -89,17 +111,19 @@ export default function DiscoverResultCard({ result }: DiscoverResultCardProps) 
                     <ExternalLink className="h-3.5 w-3.5 mt-0.5 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity" />
                 </a>
 
-                {hasMetadata && (
+                {(metadata.length > 0 || publicationTypeLabel) && (
                     <div className="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-xs text-muted-foreground">
-                        {authorsDisplay && <span>{authorsDisplay}</span>}
-                        {authorsDisplay && (publishedYear || result.source) && <span>&middot;</span>}
-                        {result.source && <span className="italic">{result.source}</span>}
-                        {result.source && publishedYear && <span>&middot;</span>}
-                        {publishedYear && <span>{publishedYear}</span>}
-                        {(authorsDisplay || publishedYear || result.source) && result.cited_by_count != null && result.cited_by_count > 0 && <span>&middot;</span>}
-                        {result.cited_by_count != null && result.cited_by_count > 0 && (
-                            <span>{result.cited_by_count.toLocaleString()} citations</span>
+                        {publicationTypeLabel && (
+                            <span className="px-1.5 py-0.5 rounded border border-slate-200 dark:border-slate-700 text-[10px] font-medium uppercase tracking-wide">
+                                {publicationTypeLabel}
+                            </span>
                         )}
+                        {metadata.map((item, idx) => (
+                            <span key={item.key} className="flex items-center gap-x-2">
+                                {idx > 0 && <span aria-hidden="true">&middot;</span>}
+                                <span>{item.node}</span>
+                            </span>
+                        ))}
                     </div>
                 )}
 

--- a/client/src/app/(main)/(protected)/discover/DiscoverResultCard.tsx
+++ b/client/src/app/(main)/(protected)/discover/DiscoverResultCard.tsx
@@ -119,9 +119,11 @@ export default function DiscoverResultCard({ result }: DiscoverResultCardProps) 
                             </span>
                         )}
                         {metadata.map((item, idx) => (
+                            // Separator trails its item so a wrapped line never opens with a
+                            // stray dot — these rows wrap often once a venue is present.
                             <span key={item.key} className="flex items-center gap-x-2">
-                                {idx > 0 && <span aria-hidden="true">&middot;</span>}
                                 <span>{item.node}</span>
+                                {idx < metadata.length - 1 && <span aria-hidden="true">&middot;</span>}
                             </span>
                         ))}
                     </div>

--- a/client/src/app/(main)/(protected)/discover/DiscoverResultCard.tsx
+++ b/client/src/app/(main)/(protected)/discover/DiscoverResultCard.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { ExternalLink } from "lucide-react"
-import type { ReactNode } from "react"
+import { useState, type ReactNode } from "react"
 
 export interface DiscoverResult {
     title: string
@@ -73,6 +73,10 @@ export default function DiscoverResultCard({ result }: DiscoverResultCardProps) 
         ? new Date(result.published_date).getFullYear()
         : null
 
+    // Some publishers 404 or 403 the favicon URL the search index reports
+    // (Springer and Wiley both do), which leaves a broken image in the title row.
+    const [faviconFailed, setFaviconFailed] = useState(false)
+
     const authorsDisplay = formatAuthors(result.authors)
     const institutionsDisplay = formatInstitutions(result.institutions)
     const publicationTypeLabel = formatPublicationType(result.publication_type)
@@ -100,11 +104,12 @@ export default function DiscoverResultCard({ result }: DiscoverResultCardProps) 
                     rel="noopener noreferrer"
                     className="font-medium text-sm hover:underline flex items-start gap-1.5"
                 >
-                    {result.favicon && (
+                    {result.favicon && !faviconFailed && (
                         <img
                             src={result.favicon}
                             alt=""
                             className="h-4 w-4 mt-0.5 flex-shrink-0 rounded-sm"
+                            onError={() => setFaviconFailed(true)}
                         />
                     )}
                     <span className="flex-1">{result.title}</span>

--- a/server/app/helpers/discover.py
+++ b/server/app/helpers/discover.py
@@ -5,8 +5,12 @@ import logging
 from datetime import datetime, timedelta
 from typing import AsyncGenerator, List, Optional
 
-from app.helpers.exa_search import search_exa
-from app.helpers.openalex_search import search_openalex
+from app.helpers.exa_search import ExaResult, search_exa
+from app.helpers.openalex_search import (
+    fetch_metadata_by_doi,
+    normalize_openalex_doi,
+    search_openalex,
+)
 from app.llm.base import BaseLLMClient, ModelType
 from app.llm.provider import LLMProvider
 from app.schemas.discover import DISCOVER_SOURCES
@@ -58,6 +62,34 @@ def _get_domains_for_sources(sources: list[str]) -> Optional[list[str]]:
             if source_domains:
                 domains.extend(source_domains)
     return domains if domains else None
+
+
+def _hydrate_from_openalex(results: list[ExaResult]) -> list[ExaResult]:
+    """Fill in the publication metadata Exa does not return.
+
+    Exa's publications index exposes no venue, and supplies citation counts and
+    institutions only sporadically. OpenAlex has all three, and both sources
+    identify works by DOI, so one batched lookup covers a whole result set. Only
+    empty fields are filled — Exa's own values win where it has them.
+    """
+    dois = [r.doi for r in results if r.doi]
+    if not dois:
+        return results
+
+    metadata = fetch_metadata_by_doi(dois)
+
+    for result in results:
+        entry = metadata.get(normalize_openalex_doi(result.doi) or "")
+        if not entry:
+            continue
+        if not result.source:
+            result.source = entry.source
+        if result.cited_by_count is None:
+            result.cited_by_count = entry.cited_by_count
+        if not result.institutions:
+            result.institutions = entry.institutions
+
+    return results
 
 
 async def run_discover_pipeline(
@@ -122,6 +154,8 @@ async def run_discover_pipeline(
                     start_published_date=start_date,
                     use_publication_index=use_publication_index,
                 )
+                if use_publication_index:
+                    results = _hydrate_from_openalex(results)
 
             yield {
                 "type": "results",

--- a/server/app/helpers/discover.py
+++ b/server/app/helpers/discover.py
@@ -98,6 +98,11 @@ async def run_discover_pipeline(
     elif year_filter == "last_5_years":
         start_date = (datetime.now() - timedelta(days=5 * 365)).strftime("%Y-%m-%d")
 
+    # Exa's publications index returns better-formed scholarly metadata and covers
+    # venues our domain allowlist omits, but it honors neither domain nor date
+    # filters. Use it only when the search asks for neither.
+    use_publication_index = not exa_domains and not start_date
+
     # Step 2: Search each subquery
     for subquery in subqueries:
         try:
@@ -115,6 +120,7 @@ async def run_discover_pipeline(
                     num_results=10,
                     domains=exa_domains,
                     start_published_date=start_date,
+                    use_publication_index=use_publication_index,
                 )
 
             yield {

--- a/server/app/helpers/exa_search.py
+++ b/server/app/helpers/exa_search.py
@@ -14,6 +14,14 @@ logger = logging.getLogger(__name__)
 
 EXA_API_KEY = os.getenv("EXA_API_KEY")
 
+# The publications index is reached over raw HTTP rather than through exa_py.
+# Upgrading the SDK does not remove the need for this: its entity parser only
+# builds company and person entities, so publication entities are dropped during
+# parsing and every result arrives with `entities` set to None — losing the
+# citation counts, abstracts, and structured authors this index exists to provide.
+EXA_SEARCH_URL = "https://api.exa.ai/search"
+EXA_REQUEST_TIMEOUT = 60.0
+
 # Exa intermittently returns transient 5xx/429s ("Please try again later"); retry
 # those a couple of times before giving up. exa_py raises a plain ValueError whose
 # message embeds the HTTP status, and surfaces transport failures as httpx errors.
@@ -21,9 +29,15 @@ EXA_MAX_RETRIES = 2
 EXA_RETRY_BASE_DELAY = 1.0
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
 
+SUMMARY_PROMPT = "You're reviewing academic literature. Describe the background and results in 2-3 sentences. The reader already knows this is a research paper, so skip meta-commentary and focus on the actual content and findings. Do not start with 'This paper' or similar phrases. Just summarize the key points."
+
 
 def _is_retryable_exa_error(e: Exception) -> bool:
     """True if an Exa failure looks transient and worth retrying."""
+    # A response we did receive is retryable only for the transient status codes;
+    # checked before HTTPError since it is a subclass.
+    if isinstance(e, httpx.HTTPStatusError):
+        return e.response.status_code in _RETRYABLE_STATUS_CODES
     # Transport-level failures (timeouts, connection resets) are transient.
     if isinstance(e, httpx.HTTPError):
         return True
@@ -32,6 +46,27 @@ def _is_retryable_exa_error(e: Exception) -> bool:
     if match:
         return int(match.group(1)) in _RETRYABLE_STATUS_CODES
     return False
+
+
+def _call_with_retries(operation, query: str):
+    """Run an Exa call, retrying transient failures with exponential backoff."""
+    for attempt in range(EXA_MAX_RETRIES + 1):
+        try:
+            return operation()
+        except Exception as e:
+            if attempt < EXA_MAX_RETRIES and _is_retryable_exa_error(e):
+                delay = EXA_RETRY_BASE_DELAY * (2**attempt)
+                logger.warning(
+                    f"Exa search transient error (attempt {attempt + 1}/{EXA_MAX_RETRIES + 1}) "
+                    f"for query '{query}': {e}. Retrying in {delay:.1f}s"
+                )
+                time.sleep(delay)
+                continue
+            logger.error(f"Exa search failed for query '{query}': {e}")
+            raise
+
+    # Unreachable: the loop either returns or raises on the final attempt.
+    raise RuntimeError("Exa search retry loop exited unexpectedly")
 
 
 @dataclass
@@ -45,6 +80,7 @@ class ExaResult:
     highlight_scores: list[float] = field(default_factory=list)
     favicon: Optional[str] = None
     summary: Optional[str] = None
+    cited_by_count: Optional[int] = None
 
     def to_dict(self) -> dict:
         return {
@@ -57,6 +93,7 @@ class ExaResult:
             "highlight_scores": self.highlight_scores,
             "favicon": self.favicon,
             "summary": self.summary,
+            "cited_by_count": self.cited_by_count,
         }
 
 
@@ -130,24 +167,13 @@ ACADEMIC_DOMAINS = [
 ]
 
 
-def search_exa(
+def _search_web_index(
     query: str,
-    num_results: int = 10,
-    domains: Optional[list[str]] = None,
-    start_published_date: Optional[str] = None,
+    num_results: int,
+    domains: Optional[list[str]],
+    start_published_date: Optional[str],
 ) -> list[ExaResult]:
-    """Search Exa for research papers matching the query.
-
-    Args:
-        query: Search query string
-        num_results: Maximum number of results to return
-        domains: Optional list of domains to filter by. If None, no domain filtering
-                 is applied (relies on category="research paper" for relevance).
-        start_published_date: Optional ISO date string (YYYY-MM-DD) for earliest publication date
-    """
-    if not EXA_API_KEY:
-        raise ValueError("EXA_API_KEY environment variable is not set")
-
+    """Search Exa's general web index, scoped to known academic domains."""
     exa = Exa(api_key=EXA_API_KEY)
 
     search_params = {
@@ -157,57 +183,153 @@ def search_exa(
         "category": "research paper",
         "text": {"max_characters": 500},
         "highlights": {"num_sentences": 3},
-        "summary": {
-            "query": "You're reviewing academic literature. Describe the background and results in 2-3 sentences. The reader already knows this is a research paper, so skip meta-commentary and focus on the actual content and findings. Do not start with 'This paper' or similar phrases. Just summarize the key points."
-        },
+        "summary": {"query": SUMMARY_PROMPT},
+        "include_domains": domains or ACADEMIC_DOMAINS,
     }
-
-    search_params["include_domains"] = domains or ACADEMIC_DOMAINS
 
     if start_published_date:
         search_params["start_published_date"] = start_published_date
 
-    for attempt in range(EXA_MAX_RETRIES + 1):
-        try:
-            response = exa.search_and_contents(**search_params)
+    response = _call_with_retries(
+        lambda: exa.search_and_contents(**search_params), query
+    )
 
-            results = []
-            for result in response.results:
-                # Skip results without a proper title
-                if not result.title or not result.title.strip():
-                    continue
+    results = []
+    for result in response.results:
+        # Skip results without a proper title
+        if not result.title or not result.title.strip():
+            continue
 
-                results.append(
-                    ExaResult(
-                        title=result.title.strip(),
-                        url=result.url,
-                        authors=[result.author] if result.author else [],
-                        published_date=result.published_date,
-                        text=result.text,
-                        highlights=result.highlights if result.highlights else [],
-                        highlight_scores=(
-                            result.highlight_scores
-                            if hasattr(result, "highlight_scores")
-                            and result.highlight_scores
-                            else []
-                        ),
-                        favicon=getattr(result, "favicon", None),
-                        summary=getattr(result, "summary", None),
-                    )
-                )
+        results.append(
+            ExaResult(
+                title=result.title.strip(),
+                url=result.url,
+                authors=[result.author] if result.author else [],
+                published_date=result.published_date,
+                text=result.text,
+                highlights=result.highlights if result.highlights else [],
+                highlight_scores=(
+                    result.highlight_scores
+                    if hasattr(result, "highlight_scores") and result.highlight_scores
+                    else []
+                ),
+                favicon=getattr(result, "favicon", None),
+                summary=getattr(result, "summary", None),
+            )
+        )
 
-            return results
-        except Exception as e:
-            if attempt < EXA_MAX_RETRIES and _is_retryable_exa_error(e):
-                delay = EXA_RETRY_BASE_DELAY * (2**attempt)
-                logger.warning(
-                    f"Exa search transient error (attempt {attempt + 1}/{EXA_MAX_RETRIES + 1}) "
-                    f"for query '{query}': {e}. Retrying in {delay:.1f}s"
-                )
-                time.sleep(delay)
-                continue
-            logger.error(f"Exa search failed for query '{query}': {e}")
-            raise
+    return results
 
-    # Unreachable: the loop either returns results or raises on the final attempt.
-    raise RuntimeError("Exa search retry loop exited unexpectedly")
+
+def _publication_authors(properties: dict) -> list[str]:
+    """Pull author names out of a publication entity's structured author list."""
+    names = []
+    for author in properties.get("authors") or []:
+        name = author.get("name") if isinstance(author, dict) else author
+        if name:
+            names.append(str(name))
+    return names
+
+
+def _parse_publication_result(raw: dict) -> Optional[ExaResult]:
+    """Map one publication-index result, or None if it has no usable title."""
+    title = (raw.get("title") or "").strip()
+    if not title:
+        return None
+
+    # Only results drawn from the publications index carry an entity; the rest
+    # come from the general web index and have web-shaped fields only.
+    entities = raw.get("entities") or []
+    properties = (entities[0].get("properties") or {}) if entities else {}
+
+    authors = _publication_authors(properties)
+    if not authors and raw.get("author"):
+        authors = [raw["author"]]
+
+    citation_count = properties.get("citationCount")
+
+    return ExaResult(
+        title=title,
+        url=raw.get("url", ""),
+        authors=authors,
+        published_date=raw.get("publishedDate") or properties.get("date"),
+        # The publisher's own abstract beats a truncated page scrape as a snippet.
+        text=properties.get("abstract") or raw.get("text"),
+        highlights=raw.get("highlights") or [],
+        highlight_scores=raw.get("highlightScores") or [],
+        favicon=raw.get("favicon"),
+        summary=raw.get("summary"),
+        cited_by_count=(
+            int(citation_count) if isinstance(citation_count, (int, float)) else None
+        ),
+    )
+
+
+def _search_publication_index(query: str, num_results: int) -> list[ExaResult]:
+    """Search Exa's dedicated publications index.
+
+    Neither domain nor date filtering is applied here. Domain filters are rejected
+    outright for this category, and date filters only constrain results that carry
+    a publication date — undated ones pass through regardless, which would make a
+    date filter quietly incomplete. Callers needing either must use the web index.
+    """
+    payload = {
+        "query": query,
+        "type": "auto",
+        "category": "publication",
+        "numResults": num_results,
+        "contents": {
+            "text": {"maxCharacters": 500},
+            "highlights": {"numSentences": 3},
+            "summary": {"query": SUMMARY_PROMPT},
+        },
+    }
+
+    headers = {
+        "x-api-key": EXA_API_KEY or "",
+        "Content-Type": "application/json",
+    }
+
+    def call():
+        response = httpx.post(
+            EXA_SEARCH_URL,
+            headers=headers,
+            json=payload,
+            timeout=EXA_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    data = _call_with_retries(call, query)
+
+    parsed = (_parse_publication_result(raw) for raw in data.get("results", []))
+    return [result for result in parsed if result]
+
+
+def search_exa(
+    query: str,
+    num_results: int = 10,
+    domains: Optional[list[str]] = None,
+    start_published_date: Optional[str] = None,
+    use_publication_index: bool = False,
+) -> list[ExaResult]:
+    """Search Exa for research papers matching the query.
+
+    Args:
+        query: Search query string
+        num_results: Maximum number of results to return
+        domains: Optional list of domains to filter by. If None, no domain filtering
+                 is applied (relies on category="research paper" for relevance).
+        start_published_date: Optional ISO date string (YYYY-MM-DD) for earliest publication date
+        use_publication_index: Search Exa's publications index instead of the web
+                 index. Yields richer metadata and reaches venues the domain
+                 allowlist misses, but supports neither `domains` nor
+                 `start_published_date`.
+    """
+    if not EXA_API_KEY:
+        raise ValueError("EXA_API_KEY environment variable is not set")
+
+    if use_publication_index:
+        return _search_publication_index(query, num_results)
+
+    return _search_web_index(query, num_results, domains, start_published_date)

--- a/server/app/helpers/exa_search.py
+++ b/server/app/helpers/exa_search.py
@@ -6,6 +6,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from typing import Optional
+from urllib.parse import unquote, urlparse
 
 import httpx
 from exa_py import Exa
@@ -28,6 +29,10 @@ EXA_REQUEST_TIMEOUT = 60.0
 EXA_MAX_RETRIES = 2
 EXA_RETRY_BASE_DELAY = 1.0
 _RETRYABLE_STATUS_CODES = {429, 500, 502, 503, 504}
+
+# Publication entities expose a DOI directly on some results and only as a
+# doi.org link on others; either is enough to look the work up in OpenAlex.
+_DOI_PATTERN = re.compile(r"(10\.\d{4,9}/[^\s\"'<>]+)", re.IGNORECASE)
 
 SUMMARY_PROMPT = "You're reviewing academic literature. Describe the background and results in 2-3 sentences. The reader already knows this is a research paper, so skip meta-commentary and focus on the actual content and findings. Do not start with 'This paper' or similar phrases. Just summarize the key points."
 
@@ -83,6 +88,12 @@ class ExaResult:
     cited_by_count: Optional[int] = None
     # "preprint", "article", "review", ... — only the publications index supplies it.
     publication_type: Optional[str] = None
+    # Journal or repository name. Named to match OpenAlexResult so the client
+    # renders both sources through the same field. Exa does not supply it —
+    # see hydrate_results_from_openalex.
+    source: Optional[str] = None
+    institutions: list[str] = field(default_factory=list)
+    doi: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -97,6 +108,9 @@ class ExaResult:
             "summary": self.summary,
             "cited_by_count": self.cited_by_count,
             "publication_type": self.publication_type,
+            "source": self.source,
+            "institutions": self.institutions,
+            "doi": self.doi,
         }
 
 
@@ -224,6 +238,19 @@ def _search_web_index(
     return results
 
 
+def _extract_doi(raw: dict, properties: dict) -> Optional[str]:
+    """The result's DOI, taken from the entity or recovered from a doi.org link."""
+    if properties.get("doi"):
+        return str(properties["doi"]).strip().lower() or None
+
+    url = raw.get("url") or ""
+    if "doi.org" not in urlparse(url).netloc:
+        return None
+
+    match = _DOI_PATTERN.search(unquote(url))
+    return match.group(1).lower().rstrip(".") if match else None
+
+
 def _publication_authors(properties: dict) -> list[str]:
     """Pull author names out of a publication entity's structured author list."""
     names = []
@@ -266,6 +293,7 @@ def _parse_publication_result(raw: dict) -> Optional[ExaResult]:
             int(citation_count) if isinstance(citation_count, (int, float)) else None
         ),
         publication_type=(properties.get("type") or None),
+        doi=_extract_doi(raw, properties),
     )
 
 

--- a/server/app/helpers/exa_search.py
+++ b/server/app/helpers/exa_search.py
@@ -81,6 +81,8 @@ class ExaResult:
     favicon: Optional[str] = None
     summary: Optional[str] = None
     cited_by_count: Optional[int] = None
+    # "preprint", "article", "review", ... — only the publications index supplies it.
+    publication_type: Optional[str] = None
 
     def to_dict(self) -> dict:
         return {
@@ -94,6 +96,7 @@ class ExaResult:
             "favicon": self.favicon,
             "summary": self.summary,
             "cited_by_count": self.cited_by_count,
+            "publication_type": self.publication_type,
         }
 
 
@@ -262,6 +265,7 @@ def _parse_publication_result(raw: dict) -> Optional[ExaResult]:
         cited_by_count=(
             int(citation_count) if isinstance(citation_count, (int, float)) else None
         ),
+        publication_type=(properties.get("type") or None),
     )
 
 

--- a/server/app/helpers/openalex_search.py
+++ b/server/app/helpers/openalex_search.py
@@ -4,10 +4,26 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from typing import Optional
+from urllib.parse import urlencode
 
-from app.helpers.paper_search import OpenAlexFilter, search_open_alex
+from app.helpers.paper_search import (
+    OpenAlexFilter,
+    _request_with_retry,
+    _with_openalex_auth,
+    search_open_alex,
+)
 
 logger = logging.getLogger(__name__)
+
+# OpenAlex accepts up to 50 values in an OR filter; leave headroom under that.
+OPENALEX_DOI_BATCH_SIZE = 40
+
+# This lookup only enriches results that are already displayable, and it sits in
+# the middle of a streaming response, so it must fail fast rather than retry.
+# The shared defaults (3 attempts, 10s each) could stall a chunk for ~30s; these
+# cap the worst case near the p99 of a healthy call, which measures under 0.7s.
+OPENALEX_HYDRATION_TIMEOUT = 5
+OPENALEX_HYDRATION_ATTEMPTS = 1
 
 
 @dataclass
@@ -38,6 +54,88 @@ class OpenAlexResult:
             "source": self.source,
             "institutions": self.institutions,
         }
+
+
+@dataclass
+class OpenAlexWorkMetadata:
+    """The subset of an OpenAlex work used to fill gaps in another source's results."""
+
+    source: Optional[str] = None
+    cited_by_count: Optional[int] = None
+    institutions: list[str] = field(default_factory=list)
+
+
+def normalize_openalex_doi(doi: Optional[str]) -> Optional[str]:
+    """Reduce a DOI to the bare, lowercased form OpenAlex filters on."""
+    if not doi:
+        return None
+    cleaned = doi.strip().lower()
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+        if cleaned.startswith(prefix):
+            cleaned = cleaned[len(prefix) :]
+    return cleaned or None
+
+
+def fetch_metadata_by_doi(dois: list[str]) -> dict[str, OpenAlexWorkMetadata]:
+    """Look up works by DOI, batched into as few requests as possible.
+
+    Returns a mapping keyed by normalized DOI, omitting anything OpenAlex has no
+    record of. Never raises: this enriches results that are already displayable,
+    so a failed lookup degrades to missing metadata rather than a failed search.
+    """
+    unique_dois = sorted({d for d in (normalize_openalex_doi(x) for x in dois) if d})
+    if not unique_dois:
+        return {}
+
+    metadata: dict[str, OpenAlexWorkMetadata] = {}
+
+    for start in range(0, len(unique_dois), OPENALEX_DOI_BATCH_SIZE):
+        batch = unique_dois[start : start + OPENALEX_DOI_BATCH_SIZE]
+        params = urlencode(
+            {
+                "filter": f"doi:{'|'.join(batch)}",
+                "per-page": OPENALEX_DOI_BATCH_SIZE + 10,
+                "select": "doi,primary_location,cited_by_count,authorships",
+            }
+        )
+        url = _with_openalex_auth(f"https://api.openalex.org/works?{params}")
+
+        try:
+            response = _request_with_retry(
+                url,
+                max_retries=OPENALEX_HYDRATION_ATTEMPTS,
+                timeout=OPENALEX_HYDRATION_TIMEOUT,
+            )
+            works = response.json().get("results", [])
+        except Exception as e:
+            logger.warning(
+                f"OpenAlex DOI lookup failed for {len(batch)} DOIs: {e}. "
+                "Continuing without the enriched metadata."
+            )
+            continue
+
+        for work in works:
+            doi = normalize_openalex_doi(work.get("doi"))
+            if not doi:
+                continue
+
+            primary_location = work.get("primary_location") or {}
+            work_source = primary_location.get("source") or {}
+
+            institutions: set[str] = set()
+            for authorship in work.get("authorships") or []:
+                for institution in authorship.get("institutions") or []:
+                    name = institution.get("display_name")
+                    if name:
+                        institutions.add(name)
+
+            metadata[doi] = OpenAlexWorkMetadata(
+                source=work_source.get("display_name"),
+                cited_by_count=work.get("cited_by_count"),
+                institutions=sorted(institutions),
+            )
+
+    return metadata
 
 
 def search_openalex(

--- a/server/tests/test_exa_publication_search.py
+++ b/server/tests/test_exa_publication_search.py
@@ -1,0 +1,235 @@
+import unittest
+from unittest.mock import MagicMock, patch
+
+import httpx
+from app.helpers import discover as discover_module
+from app.helpers.discover import run_discover_pipeline
+from app.helpers.exa_search import (
+    _is_retryable_exa_error,
+    _parse_publication_result,
+    search_exa,
+)
+
+
+def publication_payload(**overrides) -> dict:
+    """A publication-index result, shaped like the live API returns them."""
+    payload = {
+        "id": "https://exa.ai/library/publication/abc123",
+        "title": "Mamba: Linear-Time Sequence Modeling with Selective State Spaces",
+        "url": "https://doi.org/10.48550/arxiv.2312.00752",
+        "publishedDate": "2023-12-01T00:00:00.000Z",
+        "author": "Albert Gu, Tri Dao",
+        "text": "scraped page text",
+        "highlights": ["a highlight"],
+        "highlightScores": [0.9],
+        "favicon": "https://example.org/favicon.ico",
+        "summary": "a summary",
+        "entities": [
+            {
+                "type": "publication",
+                "properties": {
+                    "citationCount": 1025,
+                    "abstract": "Foundation models are almost universally based on the Transformer.",
+                    "date": "2023-12-01",
+                    "doi": "10.48550/arxiv.2312.00752",
+                    "authors": [{"name": "Albert Gu"}, {"name": "Tri Dao"}],
+                },
+            }
+        ],
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestParsePublicationResult(unittest.TestCase):
+    def test_maps_entity_metadata(self) -> None:
+        result = _parse_publication_result(publication_payload())
+
+        assert result is not None
+        self.assertEqual(result.cited_by_count, 1025)
+        self.assertEqual(result.authors, ["Albert Gu", "Tri Dao"])
+        self.assertEqual(result.published_date, "2023-12-01T00:00:00.000Z")
+        self.assertEqual(result.highlight_scores, [0.9])
+
+    def test_prefers_abstract_over_scraped_text(self) -> None:
+        result = _parse_publication_result(publication_payload())
+
+        assert result is not None
+        self.assertEqual(
+            result.text,
+            "Foundation models are almost universally based on the Transformer.",
+        )
+
+    def test_falls_back_to_scraped_text_without_abstract(self) -> None:
+        payload = publication_payload()
+        payload["entities"][0]["properties"].pop("abstract")
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertEqual(result.text, "scraped page text")
+
+    def test_untitled_result_is_dropped(self) -> None:
+        self.assertIsNone(_parse_publication_result(publication_payload(title="   ")))
+        self.assertIsNone(_parse_publication_result(publication_payload(title=None)))
+
+    def test_web_index_result_without_entity(self) -> None:
+        """Half of publication-category results come from the general web index."""
+        payload = publication_payload(entities=[])
+        payload.pop("publishedDate")
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertEqual(result.authors, ["Albert Gu, Tri Dao"])
+        self.assertIsNone(result.cited_by_count)
+        self.assertIsNone(result.published_date)
+        self.assertEqual(result.text, "scraped page text")
+
+    def test_date_falls_back_to_entity_property(self) -> None:
+        payload = publication_payload()
+        payload.pop("publishedDate")
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertEqual(result.published_date, "2023-12-01")
+
+    def test_tolerates_malformed_authors(self) -> None:
+        payload = publication_payload()
+        payload["entities"][0]["properties"]["authors"] = [
+            {"name": "Albert Gu"},
+            {"id": "no-name-key"},
+            "Tri Dao",
+        ]
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertEqual(result.authors, ["Albert Gu", "Tri Dao"])
+
+    def test_cited_by_count_ignores_non_numeric(self) -> None:
+        payload = publication_payload()
+        payload["entities"][0]["properties"]["citationCount"] = "lots"
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertIsNone(result.cited_by_count)
+
+
+class TestSearchExaDispatch(unittest.TestCase):
+    @patch("app.helpers.exa_search.EXA_API_KEY", "test-key")
+    @patch("app.helpers.exa_search.httpx.post")
+    def test_publication_index_sends_no_domain_or_date_filter(self, mock_post) -> None:
+        mock_post.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"results": [publication_payload()]},
+            raise_for_status=lambda: None,
+        )
+
+        results = search_exa(
+            "long sequence modeling",
+            num_results=10,
+            domains=["arxiv.org"],
+            start_published_date="2025-01-01",
+            use_publication_index=True,
+        )
+
+        payload = mock_post.call_args.kwargs["json"]
+        self.assertEqual(payload["category"], "publication")
+        # Exa rejects domain filters outright here, and honors date filters only
+        # for results that carry a date — so neither may be sent.
+        self.assertNotIn("includeDomains", payload)
+        self.assertNotIn("startPublishedDate", payload)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].cited_by_count, 1025)
+
+    @patch("app.helpers.exa_search.EXA_API_KEY", "test-key")
+    @patch("app.helpers.exa_search.Exa")
+    def test_web_index_is_the_default(self, mock_exa) -> None:
+        mock_exa.return_value.search_and_contents.return_value = MagicMock(results=[])
+
+        search_exa("long sequence modeling", start_published_date="2025-01-01")
+
+        params = mock_exa.return_value.search_and_contents.call_args.kwargs
+        self.assertEqual(params["category"], "research paper")
+        self.assertEqual(params["start_published_date"], "2025-01-01")
+
+
+class TestRetryClassification(unittest.TestCase):
+    def _status_error(self, code: int) -> httpx.HTTPStatusError:
+        request = httpx.Request("POST", "https://api.exa.ai/search")
+        response = httpx.Response(code, request=request)
+        return httpx.HTTPStatusError("boom", request=request, response=response)
+
+    def test_transient_status_is_retryable(self) -> None:
+        self.assertTrue(_is_retryable_exa_error(self._status_error(503)))
+        self.assertTrue(_is_retryable_exa_error(self._status_error(429)))
+
+    def test_client_error_is_not_retryable(self) -> None:
+        """A rejected domain filter returns 400 and will never succeed on retry."""
+        self.assertFalse(_is_retryable_exa_error(self._status_error(400)))
+
+    def test_transport_error_is_retryable(self) -> None:
+        self.assertTrue(_is_retryable_exa_error(httpx.ConnectTimeout("timed out")))
+
+    def test_sdk_value_error_status_is_parsed(self) -> None:
+        self.assertTrue(
+            _is_retryable_exa_error(
+                ValueError("Request failed with status code 502: x")
+            )
+        )
+        self.assertFalse(
+            _is_retryable_exa_error(
+                ValueError("Request failed with status code 400: x")
+            )
+        )
+
+
+class TestDiscoverRouting(unittest.IsolatedAsyncioTestCase):
+    async def _run(self, **kwargs) -> dict:
+        with (
+            patch.object(discover_module, "decompose_query", return_value=["sub one"]),
+            patch.object(discover_module, "search_exa", return_value=[]) as mock_search,
+        ):
+            async for _ in run_discover_pipeline("a question", **kwargs):
+                pass
+        return mock_search.call_args.kwargs
+
+    async def test_unfiltered_search_uses_publication_index(self) -> None:
+        kwargs = await self._run()
+        self.assertTrue(kwargs["use_publication_index"])
+
+    async def test_source_filter_falls_back_to_web_index(self) -> None:
+        kwargs = await self._run(sources=["arxiv"])
+        self.assertFalse(kwargs["use_publication_index"])
+        self.assertEqual(kwargs["domains"], ["arxiv.org"])
+
+    async def test_year_filter_falls_back_to_web_index(self) -> None:
+        kwargs = await self._run(year_filter="last_year")
+        self.assertFalse(kwargs["use_publication_index"])
+        self.assertIsNotNone(kwargs["start_published_date"])
+
+    async def test_unrecognized_source_still_uses_publication_index(self) -> None:
+        """Unknown keys yield no domains, so there is nothing to filter on."""
+        kwargs = await self._run(sources=["not-a-source"])
+        self.assertTrue(kwargs["use_publication_index"])
+
+    async def test_openalex_path_does_not_touch_exa(self) -> None:
+        with (
+            patch.object(discover_module, "decompose_query", return_value=["sub one"]),
+            patch.object(discover_module, "search_exa") as mock_exa,
+            patch.object(
+                discover_module, "search_openalex", return_value=[]
+            ) as mock_openalex,
+        ):
+            async for _ in run_discover_pipeline("a question", sources=["openalex"]):
+                pass
+
+        mock_exa.assert_not_called()
+        mock_openalex.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/server/tests/test_exa_publication_search.py
+++ b/server/tests/test_exa_publication_search.py
@@ -32,6 +32,7 @@ def publication_payload(**overrides) -> dict:
                     "abstract": "Foundation models are almost universally based on the Transformer.",
                     "date": "2023-12-01",
                     "doi": "10.48550/arxiv.2312.00752",
+                    "type": "preprint",
                     "authors": [{"name": "Albert Gu"}, {"name": "Tri Dao"}],
                 },
             }
@@ -50,6 +51,19 @@ class TestParsePublicationResult(unittest.TestCase):
         self.assertEqual(result.authors, ["Albert Gu", "Tri Dao"])
         self.assertEqual(result.published_date, "2023-12-01T00:00:00.000Z")
         self.assertEqual(result.highlight_scores, [0.9])
+        self.assertEqual(result.publication_type, "preprint")
+
+    def test_publication_type_absent_without_entity(self) -> None:
+        result = _parse_publication_result(publication_payload(entities=[]))
+
+        assert result is not None
+        self.assertIsNone(result.publication_type)
+
+    def test_publication_type_serialized_for_client(self) -> None:
+        payload = _parse_publication_result(publication_payload())
+
+        assert payload is not None
+        self.assertEqual(payload.to_dict()["publication_type"], "preprint")
 
     def test_prefers_abstract_over_scraped_text(self) -> None:
         result = _parse_publication_result(publication_payload())

--- a/server/tests/test_exa_publication_search.py
+++ b/server/tests/test_exa_publication_search.py
@@ -3,11 +3,18 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 from app.helpers import discover as discover_module
+from app.helpers import openalex_search as openalex_module
 from app.helpers.discover import run_discover_pipeline
 from app.helpers.exa_search import (
+    ExaResult,
     _is_retryable_exa_error,
     _parse_publication_result,
     search_exa,
+)
+from app.helpers.openalex_search import (
+    OpenAlexWorkMetadata,
+    fetch_metadata_by_doi,
+    normalize_openalex_doi,
 )
 
 
@@ -64,6 +71,14 @@ class TestParsePublicationResult(unittest.TestCase):
 
         assert payload is not None
         self.assertEqual(payload.to_dict()["publication_type"], "preprint")
+
+    def test_venue_is_left_for_openalex_to_supply(self) -> None:
+        """Exa exposes no venue on publication entities; it arrives via hydration."""
+        result = _parse_publication_result(publication_payload())
+
+        assert result is not None
+        self.assertIsNone(result.source)
+        self.assertIn("source", result.to_dict())
 
     def test_prefers_abstract_over_scraped_text(self) -> None:
         result = _parse_publication_result(publication_payload())
@@ -130,6 +145,185 @@ class TestParsePublicationResult(unittest.TestCase):
 
         assert result is not None
         self.assertIsNone(result.cited_by_count)
+
+
+class TestExtractDoi(unittest.TestCase):
+    def test_prefers_entity_doi(self) -> None:
+        result = _parse_publication_result(publication_payload())
+
+        assert result is not None
+        self.assertEqual(result.doi, "10.48550/arxiv.2312.00752")
+
+    def test_recovers_doi_from_doi_org_url(self) -> None:
+        payload = publication_payload(url="https://doi.org/10.1038/s41467-023-40601-6")
+        payload["entities"][0]["properties"].pop("doi")
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertEqual(result.doi, "10.1038/s41467-023-40601-6")
+
+    def test_ignores_non_doi_urls(self) -> None:
+        payload = publication_payload(url="https://www.nature.com/articles/s41467-1")
+        payload["entities"][0]["properties"].pop("doi")
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertIsNone(result.doi)
+
+    def test_normalizes_case(self) -> None:
+        payload = publication_payload()
+        payload["entities"][0]["properties"]["doi"] = "10.1038/S41467-ABC"
+
+        result = _parse_publication_result(payload)
+
+        assert result is not None
+        self.assertEqual(result.doi, "10.1038/s41467-abc")
+
+
+class TestNormalizeOpenAlexDoi(unittest.TestCase):
+    def test_strips_url_and_scheme_prefixes(self) -> None:
+        for value in (
+            "https://doi.org/10.1038/abc",
+            "http://doi.org/10.1038/abc",
+            "doi:10.1038/abc",
+            "10.1038/ABC",
+            "  10.1038/abc  ",
+        ):
+            self.assertEqual(normalize_openalex_doi(value), "10.1038/abc")
+
+    def test_empty(self) -> None:
+        self.assertIsNone(normalize_openalex_doi(None))
+        self.assertIsNone(normalize_openalex_doi(""))
+
+
+class TestHydrateFromOpenAlex(unittest.TestCase):
+    def _result(self, **kwargs) -> ExaResult:
+        defaults = dict(
+            title="A paper", url="https://doi.org/10.1038/abc", doi="10.1038/abc"
+        )
+        defaults.update(kwargs)
+        return ExaResult(**defaults)
+
+    @patch.object(discover_module, "fetch_metadata_by_doi")
+    def test_fills_missing_fields(self, mock_fetch) -> None:
+        mock_fetch.return_value = {
+            "10.1038/abc": OpenAlexWorkMetadata(
+                source="Nature Communications",
+                cited_by_count=116,
+                institutions=["ETH Zurich"],
+            )
+        }
+
+        [result] = discover_module._hydrate_from_openalex([self._result()])
+
+        self.assertEqual(result.source, "Nature Communications")
+        self.assertEqual(result.cited_by_count, 116)
+        self.assertEqual(result.institutions, ["ETH Zurich"])
+
+    @patch.object(discover_module, "fetch_metadata_by_doi")
+    def test_does_not_overwrite_values_exa_supplied(self, mock_fetch) -> None:
+        mock_fetch.return_value = {
+            "10.1038/abc": OpenAlexWorkMetadata(source="Wrong", cited_by_count=1)
+        }
+
+        [result] = discover_module._hydrate_from_openalex(
+            [self._result(source="Nature", cited_by_count=999)]
+        )
+
+        self.assertEqual(result.source, "Nature")
+        self.assertEqual(result.cited_by_count, 999)
+
+    @patch.object(discover_module, "fetch_metadata_by_doi")
+    def test_zero_citations_is_not_treated_as_missing(self, mock_fetch) -> None:
+        """0 is a real citation count and must not be overwritten by OpenAlex."""
+        mock_fetch.return_value = {
+            "10.1038/abc": OpenAlexWorkMetadata(cited_by_count=42)
+        }
+
+        [result] = discover_module._hydrate_from_openalex(
+            [self._result(cited_by_count=0)]
+        )
+
+        self.assertEqual(result.cited_by_count, 0)
+
+    @patch.object(discover_module, "fetch_metadata_by_doi")
+    def test_skips_lookup_when_no_dois(self, mock_fetch) -> None:
+        results = discover_module._hydrate_from_openalex([self._result(doi=None)])
+
+        mock_fetch.assert_not_called()
+        self.assertIsNone(results[0].source)
+
+    @patch.object(discover_module, "fetch_metadata_by_doi")
+    def test_unmatched_doi_leaves_result_untouched(self, mock_fetch) -> None:
+        mock_fetch.return_value = {}
+
+        [result] = discover_module._hydrate_from_openalex([self._result()])
+
+        self.assertIsNone(result.source)
+        self.assertEqual(result.institutions, [])
+
+
+class TestFetchMetadataByDoi(unittest.TestCase):
+    @patch.object(openalex_module, "_request_with_retry")
+    def test_lookup_is_bounded_so_a_stall_cannot_hold_the_stream(
+        self, mock_request
+    ) -> None:
+        """Enrichment must fail fast; the shared defaults would allow a ~30s stall."""
+        mock_request.return_value = MagicMock(json=lambda: {"results": []})
+
+        fetch_metadata_by_doi(["10.1038/abc"])
+
+        kwargs = mock_request.call_args.kwargs
+        self.assertEqual(kwargs["max_retries"], 1)
+        self.assertLessEqual(kwargs["timeout"], 5)
+
+    @patch.object(openalex_module, "_request_with_retry")
+    def test_network_failure_degrades_to_no_metadata(self, mock_request) -> None:
+        mock_request.side_effect = RuntimeError("openalex unreachable")
+
+        self.assertEqual(fetch_metadata_by_doi(["10.1038/abc"]), {})
+
+    @patch.object(openalex_module, "_request_with_retry")
+    def test_batches_large_doi_sets(self, mock_request) -> None:
+        mock_request.return_value = MagicMock(json=lambda: {"results": []})
+
+        fetch_metadata_by_doi([f"10.1000/{i}" for i in range(95)])
+
+        self.assertEqual(mock_request.call_count, 3)
+
+    @patch.object(openalex_module, "_request_with_retry")
+    def test_no_request_without_dois(self, mock_request) -> None:
+        self.assertEqual(fetch_metadata_by_doi([None, "", "  "]), {})
+        mock_request.assert_not_called()
+
+    @patch.object(openalex_module, "_request_with_retry")
+    def test_maps_venue_citations_and_institutions(self, mock_request) -> None:
+        mock_request.return_value = MagicMock(
+            json=lambda: {
+                "results": [
+                    {
+                        "doi": "https://doi.org/10.1038/ABC",
+                        "cited_by_count": 116,
+                        "primary_location": {
+                            "source": {"display_name": "Nature Communications"}
+                        },
+                        "authorships": [
+                            {"institutions": [{"display_name": "ETH Zurich"}]},
+                            {"institutions": [{"display_name": "ETH Zurich"}]},
+                        ],
+                    }
+                ]
+            }
+        )
+
+        metadata = fetch_metadata_by_doi(["10.1038/abc"])
+
+        self.assertEqual(metadata["10.1038/abc"].source, "Nature Communications")
+        self.assertEqual(metadata["10.1038/abc"].cited_by_count, 116)
+        # Repeated affiliations collapse to one entry.
+        self.assertEqual(metadata["10.1038/abc"].institutions, ["ETH Zurich"])
 
 
 class TestSearchExaDispatch(unittest.TestCase):


### PR DESCRIPTION
Exa shipped a dedicated publications index (~350M papers, 30M authors) exposed as `category="publication"`. Discover currently searches with category="research paper" plus a hand-maintained allowlist of ~60 academic domains (`ACADEMIC_DOMAINS` in server/app/helpers/exa_search.py). This PR covers how to adopt the new category. The `Explore` type without any venue filters will now use the Exa publication category for finding matching papers.

Some of the results come with more useful metadata, such as citation count. For others, add a minimal hydration step via OA that adds some nominal latency to the result.