### PR TITLE
Improve Crossref DOI Lookup Accuracy, Latency and Error Log Noise

### DIFF
--- a/server/app/helpers/paper_search.py
+++ b/server/app/helpers/paper_search.py
@@ -653,34 +653,23 @@ def get_doi(title: str, authors: Optional[List[str]] = None) -> Optional[str]:
     if not title:
         return None
 
-    try:
-        crossref_doi = get_crossref_doi(title, authors)
-    except requests.RequestException as e:
-        _log_lookup_failure("CrossRef", f"DOI - {title}", e)
-        crossref_doi = None
+    sources = (
+        ("CrossRef", lambda: get_crossref_doi(title, authors)),
+        ("OpenAlex", lambda: get_openalex_doi(title)),
+        ("Semantic Scholar", lambda: search_semantic_scholar_doi(title)),
+    )
 
-    try:
-        openalex_doi = get_openalex_doi(title)
-    except requests.RequestException as e:
-        _log_lookup_failure("OpenAlex", f"DOI - {title}", e)
-        openalex_doi = None
+    for service, lookup in sources:
+        try:
+            doi = lookup()
+        except requests.RequestException as e:
+            _log_lookup_failure(service, f"DOI - {title}", e)
+            continue
+        if doi:
+            logger.info(f"Found DOI from {service}: {doi} for title: {title}")
+            return doi
 
-    try:
-        semantic_scholar_doi = search_semantic_scholar_doi(title)
-    except requests.RequestException as e:
-        _log_lookup_failure("Semantic Scholar", f"DOI - {title}", e)
-        semantic_scholar_doi = None
-
-    if crossref_doi:
-        logger.info(f"Found DOI from CrossRef: {crossref_doi} for title: {title}")
-    elif openalex_doi:
-        logger.info(f"Found DOI from OpenAlex: {openalex_doi} for title: {title}")
-    elif semantic_scholar_doi:
-        logger.info(
-            f"Found DOI from Semantic Scholar: {semantic_scholar_doi} for title: {title}"
-        )
-
-    return crossref_doi or openalex_doi or semantic_scholar_doi
+    return None
 
 
 def get_enriched_data(doi: str) -> Optional[EnrichedData]:

--- a/server/app/helpers/paper_search.py
+++ b/server/app/helpers/paper_search.py
@@ -16,6 +16,28 @@ OPENALEX_MAX_RETRIES = 3
 OPENALEX_RETRY_DELAY = 1  # seconds
 OPENALEX_API_KEY = os.getenv("OPENALEX_API_KEY")
 
+# Failures we expect from free upstream APIs. They resolve on their own, so they
+# are logged as warnings rather than errors.
+TRANSIENT_HTTP_STATUSES = {408, 429, 500, 502, 503, 504}
+
+
+def _is_transient(exc: requests.RequestException) -> bool:
+    """Whether the failure is an upstream blip rather than something to fix here."""
+    response = getattr(exc, "response", None)
+    if response is not None:
+        return response.status_code in TRANSIENT_HTTP_STATUSES
+    return isinstance(exc, (requests.Timeout, requests.ConnectionError))
+
+
+def _log_lookup_failure(
+    service: str, context: str, exc: requests.RequestException
+) -> None:
+    """Log an upstream lookup failure, reserving error level for actionable ones."""
+    if _is_transient(exc):
+        logger.warning(f"{service} lookup unavailable for {context}: {exc}")
+    else:
+        logger.error(f"Error querying {service} API for {context}", exc_info=exc)
+
 
 def _with_openalex_auth(url: str) -> str:
     """Append the OpenAlex api_key query parameter to a URL if configured."""
@@ -33,7 +55,7 @@ def _request_with_retry(
     timeout: int = 10,
 ) -> requests.Response:
     """
-    Make an HTTP request with automatic retry on failure.
+    Make an HTTP request, with automatic retry on recoverable failures.
 
     Args:
         url: The URL to request.
@@ -57,18 +79,39 @@ def _request_with_retry(
             return response
         except requests.RequestException as e:
             last_exception = e
-            if attempt < max_retries - 1:
-                logger.warning(
-                    f"OpenAlex API request failed (attempt {attempt + 1}/{max_retries}): {e}. "
-                    f"Retrying in {retry_delay}s..."
+            if not _is_transient(e) or attempt == max_retries - 1:
+                _log_lookup_failure(
+                    "OpenAlex", f"{url} after {attempt + 1} attempt(s)", e
                 )
-                time.sleep(retry_delay)
-            else:
-                logger.error(
-                    f"OpenAlex API request failed after {max_retries} attempts: {e}"
-                )
+                break
+            logger.warning(
+                f"OpenAlex API request failed (attempt {attempt + 1}/{max_retries}): {e}. "
+                f"Retrying in {retry_delay}s..."
+            )
+            time.sleep(retry_delay)
 
     raise last_exception  # type: ignore
+
+
+CROSSREF_MAX_ATTEMPTS = 3
+CROSSREF_RETRY_DELAY = 2  # seconds, doubled per attempt
+# UA with mailto to use Crossref's polite pool rate limits, worth 3 req/s and 3 concurrent on search queries vs default 1.
+CROSSREF_MAILTO = os.getenv("CROSSREF_MAILTO", "team@khoj.dev")
+CROSSREF_USER_AGENT = f"OpenPaper/1.0 (https://openpaper.ai); mailto:{CROSSREF_MAILTO}"
+
+
+def _crossref_get(url: str, params: Optional[dict] = None) -> requests.Response:
+    """GET from Crossref, backing off on rate limits before returning the response."""
+    headers = {"User-Agent": CROSSREF_USER_AGENT}
+    response = requests.get(url, params=params, headers=headers, timeout=10)
+    for attempt in range(CROSSREF_MAX_ATTEMPTS - 1):
+        if response.status_code != 429:
+            break
+        delay = CROSSREF_RETRY_DELAY * 2**attempt
+        logger.warning(f"CrossRef rate limited {url}. Retrying in {delay}s...")
+        time.sleep(delay)
+        response = requests.get(url, params=params, headers=headers, timeout=10)
+    return response
 
 
 SEMANTIC_SCHOLAR_API_KEY = os.getenv("SEMANTIC_SCHOLAR_API_KEY")
@@ -355,14 +398,13 @@ def get_host_organization_name(host_organization_url: str) -> Optional[str]:
             else:
                 response.raise_for_status()
         except requests.RequestException as e:
-            if attempt < OPENALEX_MAX_RETRIES - 1:
-                logger.warning(
-                    f"Error fetching host organization (attempt {attempt + 1}): {e}. Retrying..."
-                )
-                time.sleep(OPENALEX_RETRY_DELAY)
-            else:
-                logger.exception(f"Error fetching host organization: {url}")
+            if not _is_transient(e) or attempt == OPENALEX_MAX_RETRIES - 1:
+                _log_lookup_failure("OpenAlex", f"host organization - {url}", e)
                 return None
+            logger.warning(
+                f"Error fetching host organization (attempt {attempt + 1}): {e}. Retrying..."
+            )
+            time.sleep(OPENALEX_RETRY_DELAY)
     return None
 
 
@@ -407,13 +449,12 @@ def get_paper_by_open_alex_id(open_alex_id: str) -> Optional[OpenAlexWork]:
             else:
                 response.raise_for_status()
         except requests.RequestException as e:
-            if attempt < OPENALEX_MAX_RETRIES - 1:
-                logger.warning(
-                    f"Error fetching paper by OpenAlex ID (attempt {attempt + 1}): {e}. Retrying..."
-                )
-                time.sleep(OPENALEX_RETRY_DELAY)
-            else:
+            if not _is_transient(e) or attempt == OPENALEX_MAX_RETRIES - 1:
                 raise
+            logger.warning(
+                f"Error fetching paper by OpenAlex ID (attempt {attempt + 1}): {e}. Retrying..."
+            )
+            time.sleep(OPENALEX_RETRY_DELAY)
     return None
 
 
@@ -447,13 +488,12 @@ def get_work_by_doi(doi: str) -> Optional[OpenAlexWork]:
             else:
                 response.raise_for_status()
         except requests.RequestException as e:
-            if attempt < OPENALEX_MAX_RETRIES - 1:
-                logger.warning(
-                    f"Error fetching work by DOI (attempt {attempt + 1}): {e}. Retrying..."
-                )
-                time.sleep(OPENALEX_RETRY_DELAY)
-            else:
+            if not _is_transient(e) or attempt == OPENALEX_MAX_RETRIES - 1:
                 raise
+            logger.warning(
+                f"Error fetching work by DOI (attempt {attempt + 1}): {e}. Retrying..."
+            )
+            time.sleep(OPENALEX_RETRY_DELAY)
     return None
 
 
@@ -577,7 +617,7 @@ def get_doi(title: str, authors: Optional[List[str]] = None) -> Optional[str]:
         if authors:
             params["query.author"] = ", ".join(authors)
 
-        response = requests.get(base_url, params=params, timeout=10)
+        response = _crossref_get(base_url, params=params)
         response.raise_for_status()
         data = response.json()
         items = data.get("message", {}).get("items", [])
@@ -615,26 +655,20 @@ def get_doi(title: str, authors: Optional[List[str]] = None) -> Optional[str]:
 
     try:
         crossref_doi = get_crossref_doi(title, authors)
-    except requests.RequestException:
-        logger.exception(
-            f"Error querying CrossRef API for DOI - {title}", exc_info=True
-        )
+    except requests.RequestException as e:
+        _log_lookup_failure("CrossRef", f"DOI - {title}", e)
         crossref_doi = None
 
     try:
         openalex_doi = get_openalex_doi(title)
-    except requests.RequestException:
-        logger.exception(
-            f"Error querying OpenAlex API for DOI - {title}", exc_info=True
-        )
+    except requests.RequestException as e:
+        _log_lookup_failure("OpenAlex", f"DOI - {title}", e)
         openalex_doi = None
 
     try:
         semantic_scholar_doi = search_semantic_scholar_doi(title)
-    except requests.RequestException:
-        logger.exception(
-            f"Error querying Semantic Scholar API for DOI - {title}", exc_info=True
-        )
+    except requests.RequestException as e:
+        _log_lookup_failure("Semantic Scholar", f"DOI - {title}", e)
         semantic_scholar_doi = None
 
     if crossref_doi:
@@ -686,6 +720,9 @@ def get_enriched_data(doi: str) -> Optional[EnrichedData]:
                     publication_date=publication_date,
                 )
 
+        except requests.RequestException as e:
+            _log_lookup_failure("OpenAlex", f"enriched data - {doi}", e)
+            return None
         except Exception:
             logger.error(
                 f"Error when querying Open Alex API for DOI {doi}", exc_info=True
@@ -695,7 +732,7 @@ def get_enriched_data(doi: str) -> Optional[EnrichedData]:
 
     def get_crossref_enriched_data(doi: str) -> Optional[EnrichedData]:
         base_url = f"https://api.crossref.org/works/{quote(doi)}"
-        response = requests.get(base_url, timeout=10)
+        response = _crossref_get(base_url)
         if response.status_code == 404:
             # DOI not found in CrossRef (common for arXiv, DataCite DOIs)
             return None
@@ -735,10 +772,8 @@ def get_enriched_data(doi: str) -> Optional[EnrichedData]:
         if openalex_data:
             logger.info(f"Found enriched data from OpenAlex for DOI: {doi}")
             return openalex_data
-    except requests.RequestException:
-        logger.exception(
-            f"Error querying OpenAlex API for enriched data - {doi}", exc_info=True
-        )
+    except requests.RequestException as e:
+        _log_lookup_failure("OpenAlex", f"enriched data - {doi}", e)
 
     try:
         crossref_data = get_crossref_enriched_data(doi)
@@ -746,9 +781,7 @@ def get_enriched_data(doi: str) -> Optional[EnrichedData]:
             logger.info(f"Found enriched data from CrossRef for DOI: {doi}")
             return crossref_data
 
-    except requests.RequestException:
-        logger.exception(
-            f"Error querying CrossRef API for enriched data - {doi}", exc_info=True
-        )
+    except requests.RequestException as e:
+        _log_lookup_failure("CrossRef", f"enriched data - {doi}", e)
 
     return None

--- a/server/app/helpers/paper_search.py
+++ b/server/app/helpers/paper_search.py
@@ -613,7 +613,7 @@ def get_doi(title: str, authors: Optional[List[str]] = None) -> Optional[str]:
         title: str, authors: Optional[List[str]] = None
     ) -> Optional[str]:
         base_url = "https://api.crossref.org/works"
-        params = {"query.title": quote(title), "rows": 1}
+        params = {"query.title": title, "rows": 1}
         if authors:
             params["query.author"] = ", ".join(authors)
 


### PR DESCRIPTION
## Why

A crossref 429 was logged with `logger.exception`, so an upstream rate limit surfaced at the same severity as a bug in our own code. There is nothing to act on: the rate limit clears itself and the lookup already falls through to openalex.

Two more issues surfaced while measuring that fix. Titles were being sent to crossref doubly encoded, quietly cutting the match rate roughly in half. And `get_doi` ran every provider unconditionally, so each lookup paid for openalex even when crossref had already answered.

## What

### Keep Unactionable Upstream Failures Out of Error Logs
- Sort failures by whether anyone can act on them
  - 408/429/5xx, timeouts and connection errors log a single warning line
  - Everything else keeps its error and traceback
- Gate the retry loops on the same predicate
  A 400/401/403 now fails on the first attempt instead of sleeping ~2s to re-ask a question that has already been answered
- Join crossref's polite pool with a `mailto` in the user-agent
  - Worth 3 req/s and 3 concurrent on search queries, against 1 and 1 anonymously
  - Set `CROSSREF_MAILTO` to override the default contact address
- Retry a 429 twice, backing off 2s then 4s. Crossref sends no `Retry-After` header

### Fix Doubly Encoded Titles in Crossref DOI Search
- Drop a stray `quote()` on `query.title`. `requests` percent-encodes params itself, so titles went out as `The%2520Tie%2520That%2520Binds`
- Crossref fuzzy-matched through the noise rather than erroring, which is why this went unnoticed
- Correct DOI recovered, over 42 random journal articles re-searched by their own title:

  |                | doubly encoded | clean |
  |----------------|----------------|-------|
  | all titles     | 23/42          | 38/42 |
  | ascii only     | 18/30          | 26/30 |
  | non-ascii      | 5/12           | 12/12 |

### Short-Circuit the DOI Lookup Once a Source Answers
- Return on the first provider that answers, instead of running all three and only picking a winner at the end
- Short-circuit on the doi rather than on request success, to keep falling through on a no-match
- Openalex is the expensive leg, at a median 881ms against crossref's 325ms. Measured over 36 titles:

  |        | mean   | median | upstream calls |
  |--------|--------|--------|----------------|
  | before | 1258ms | 1226ms | 2.00           |
  | after  | 519ms  | 335ms  | 1.14           |

- Chose not to run providers in parallel and take the first answer
  It is no faster at the median, since crossref is both preferred and quicker, and it would hold two concurrent upstream requests per worker against crossref's limit of three

### Test
- Exercise retry gating, log severity, short-circuit ordering and crossref backoff against mocked transports
- Verify each commit compiles and passes `black --check` independently
- `python -m unittest discover -s tests` unchanged. Same 5 pre-existing import errors (`exa_py`, `pypdf`) in unrelated modules
